### PR TITLE
C-WCOW: Add security policy plumbing on hcsshim side

### DIFF
--- a/cmd/gcs-sidecar/internal/bridge/handlers.go
+++ b/cmd/gcs-sidecar/internal/bridge/handlers.go
@@ -295,7 +295,8 @@ func unMarshalAndModifySettings(modifySettingsRequest *hcsschema.ModifySettingRe
 			wcowMappedVirtualDisk := guestModificationRequest.Settings.(*guestresource.WCOWMappedVirtualDisk)
 			log.Printf(", wcowMappedVirtualDisk { %v} \n", wcowMappedVirtualDisk)
 		// TODO need a case similar to guestresource.ResourceTypeSecurityPolicy of lcow?
-		// case guestresource.ResourceTypeSecurityPolicy:
+		case guestresource.ResourceTypeSecurityPolicy:
+			log.Printf("This is the C-WCOW security policy invocation")
 		case guestresource.ResourceTypeHvSocket:
 			hvSocketAddress := guestModificationRequest.Settings.(*hcsschema.HvSocketAddress)
 			log.Printf(", hvSocketAddress { %v} \n", hvSocketAddress)

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -341,6 +341,8 @@ func SpecToUVMCreateOpts(ctx context.Context, s *specs.Spec, id, owner string) (
 		wopts.NoDirectMap = ParseAnnotationsBool(ctx, s.Annotations, annotations.VSMBNoDirectMap, wopts.NoDirectMap)
 		wopts.NoInheritHostTimezone = ParseAnnotationsBool(ctx, s.Annotations, annotations.NoInheritHostTimezone, wopts.NoInheritHostTimezone)
 		wopts.AdditionalRegistryKeys = append(wopts.AdditionalRegistryKeys, parseAdditionalRegistryValues(ctx, s.Annotations)...)
+		wopts.WCOWSecurityPolicy = ParseAnnotationsString(s.Annotations, annotations.WCOWSecurityPolicy, wopts.WCOWSecurityPolicy)
+		wopts.WCOWSecurityPolicyEnforcer = ParseAnnotationsString(s.Annotations, annotations.SecurityPolicyEnforcer, wopts.WCOWSecurityPolicyEnforcer)
 		handleAnnotationFullyPhysicallyBacked(ctx, s.Annotations, wopts)
 		return wopts, nil
 	}

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -195,3 +195,10 @@ type LCOWConfidentialOptions struct {
 type LCOWSecurityPolicyFragment struct {
 	Fragment string `json:"Fragment,omitempty"`
 }
+
+// TODO (Mahati): Move this out later: WCOWConfidentialOptions is used to set various confidential container specific
+// options.
+type WCOWConfidentialOptions struct {
+	EnforcerType          string `json:"EnforcerType,omitempty"`
+	EncodedSecurityPolicy string `json:"EncodedSecurityPolicy,omitempty"`
+}

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -363,6 +363,16 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		}
 	}
 
+	if uvm.WCOWconfidentialUVMOptions != nil && uvm.OS() == "windows" {
+		copts := []WCOWConfidentialUVMOpt{
+			WithWCOWSecurityPolicy(uvm.WCOWconfidentialUVMOptions.WCOWSecurityPolicy),
+			WithWCOWSecurityPolicyEnforcer(uvm.WCOWconfidentialUVMOptions.WCOWSecurityPolicyEnforcer),
+		}
+		if err := uvm.SetWCOWConfidentialUVMOptions(ctx, copts...); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/internal/uvm/types.go
+++ b/internal/uvm/types.go
@@ -139,6 +139,9 @@ type UtilityVM struct {
 
 	// confidentialUVMOptions hold confidential UVM specific options
 	confidentialUVMOptions *ConfidentialOptions
+
+	// WCOWconfidentialUVMOptions hold confidential UVM specific options
+	WCOWconfidentialUVMOptions *WCOWConfidentialOptions
 }
 
 func (uvm *UtilityVM) ScratchEncryptionEnabled() bool {

--- a/pkg/annotations/annotations.go
+++ b/pkg/annotations/annotations.go
@@ -228,6 +228,13 @@ const (
 	// This allows for better fallback mechanics.
 	SecurityPolicyEnforcer = "io.microsoft.virtualmachine.lcow.enforcer"
 
+	// WCOW SecurityPolicy is used to specify a security policy for opengcs to enforce.
+	WCOWSecurityPolicy = "io.microsoft.virtualmachine.wcow.securitypolicy"
+
+	// WCOW SecurityPolicyEnforcer is used to specify which enforcer to initialize (open-door, standard or rego).
+	// This allows for better fallback mechanics.
+	WCOWSecurityPolicyEnforcer = "io.microsoft.virtualmachine.wcow.enforcer"
+
 	// HclEnabled specifies whether to enable the host compatibility layer.
 	HclEnabled = "io.microsoft.virtualmachine.lcow.hcl-enabled"
 
@@ -289,6 +296,9 @@ const (
 
 	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
 	UVMReferenceInfoFile = "io.microsoft.virtualmachine.lcow.uvm-reference-info-file"
+
+	// UVMReferenceInfoFile specifies the filename of a signed UVM reference file to be passed to UVM.
+	WCOWUVMReferenceInfoFile = "io.microsoft.virtualmachine.wcow.uvm-reference-info-file"
 
 	// HostAMDCertificate specifies the filename of the AMD certificates to be passed to UVM.
 	// The certificate is expected to be located in the same directory as the shim executable.


### PR DESCRIPTION
- This PR adds the plumbing for the confidential WCOW security policy on the hcsshim side 
  - Adds WCOW confidential options data structures
  - Adds relevant annotations (minimal for now, more will be added later)
  - Adds relevant function invocations on uvm start