### PR TITLE
Fix build break after merge with hcsshim/main

### DIFF
--- a/cmd/gcs-sidecar/internal/windowssecuritypolicy/securitypolicyenforcer_rego.go
+++ b/cmd/gcs-sidecar/internal/windowssecuritypolicy/securitypolicyenforcer_rego.go
@@ -19,7 +19,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	rpi "github.com/Microsoft/hcsshim/internal/regopolicyinterpreter"
-	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/moby/sys/user"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )


### PR DESCRIPTION
github.com/opencontainers/runc/libcontainer/user has been deprecated after version update. This was breaking gcs-sidecar build after merging hcsshim/main to c-wcow-dev. This commit fixes it.