### PR TITLE
Scratch format sidecar inside uvm

### DIFF
--- a/cmd/gcs-sidecar/internal/bridge/bridge.go
+++ b/cmd/gcs-sidecar/internal/bridge/bridge.go
@@ -180,9 +180,11 @@ func getMessageType(header [hdrSize]byte) msgType {
 	return msgType(binary.LittleEndian.Uint32(header[hdrOffType:]))
 }
 
-func setMessageSize() {
-
+func setRequestSize(req *request, messageSize uint32) {
+	size := messageSize + hdrSize
+	binary.LittleEndian.PutUint32(req.header[hdrOffSize:], size)
 }
+
 func getMessageSize(header [hdrSize]byte) uint32 {
 	return binary.LittleEndian.Uint32(header[hdrOffSize:])
 }

--- a/cmd/gcs-sidecar/internal/bridge/handlers.go
+++ b/cmd/gcs-sidecar/internal/bridge/handlers.go
@@ -279,7 +279,7 @@ func (b *Bridge) unmarshalModifySettingsAndForward(req *request) error {
 		case guestresource.ResourceTypeCWCOWCombinedLayers:
 			settings := &guestresource.CWCOWCombinedLayers{}
 			if err := json.Unmarshal(rawGuestRequest, settings); err != nil {
-				log.Printf("invalid ResourceTypeCombinedLayers request %v", r)
+				log.Printf("invalid ResourceTypeWCOWCombinedLayers request %v", r)
 				return fmt.Errorf("invalid ResourceTypeCombinedLayers request %v", r)
 			}
 			containerID := settings.ContainerID
@@ -307,8 +307,7 @@ func (b *Bridge) unmarshalModifySettingsAndForward(req *request) error {
 
 			var newRequest request
 			newRequest.header = req.header
-			size := uint32(len(buf)) + hdrSize
-			binary.LittleEndian.PutUint32(newRequest.header[hdrOffSize:], size)
+			setRequestSize(&newRequest, uint32(len(buf)))
 			newRequest.message = buf
 			req = &newRequest
 

--- a/cmd/refs-util/main.go
+++ b/cmd/refs-util/main.go
@@ -1,0 +1,55 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/Microsoft/hcsshim/internal/fsformatter"
+	"github.com/Microsoft/hcsshim/internal/windevice"
+)
+
+func main() {
+	args := os.Args
+
+	if len(args) == 1 || len(args) > 3 {
+		fmt.Println("controller and lun not provided")
+		return
+	}
+
+	// Testing in local VM: controller 0 and lun 1
+	controller := 0
+	lun := 0
+	for i, arg := range args[1:] {
+		if i == 0 {
+			controller, _ = strconv.Atoi(arg)
+		} else if i == 1 {
+			lun, _ = strconv.Atoi(arg)
+		}
+	}
+
+	fmt.Printf("Controller: %d, Lun: %d \n", controller, lun)
+
+	ctx := context.Background()
+	devPath, diskNumber, err := windevice.GetScsiDevicePathAndDiskNumberFromControllerLUN(ctx,
+		uint8(controller),
+		uint8(lun))
+	if err != nil {
+		fmt.Printf("error getting diskNumber for LUN %d", lun)
+	}
+	fmt.Printf("\n DevicePath: %v DiskNumber: %v \n", devPath, diskNumber)
+
+	diskPath := fmt.Sprintf(fsformatter.VirtualDevObjectPathFormat, diskNumber)
+	fmt.Printf("\n Disk path is %v", diskPath)
+
+	mountedVolumePath, err := windevice.InvokeFsFormatter(ctx, diskPath)
+	if err != nil {
+		fmt.Printf("error invoking formatter %v", err)
+	}
+	log.Printf("\n mountedVolumePath returned from InvokeFsFormatter: %v", mountedVolumePath)
+}

--- a/internal/fsformatter/formatter_driver.go
+++ b/internal/fsformatter/formatter_driver.go
@@ -1,0 +1,234 @@
+package fsformatter
+
+import (
+	"encoding/binary"
+	"log"
+	"unicode/utf16"
+	"unsafe"
+)
+
+const (
+	// This is used to construct the disk path that fsFormatter
+	// understands. `harddisk%d` here refers to the disk number
+	// associated with the corresponding lun of the attached
+	// scsi device.
+	VirtualDevObjectPathFormat                              = "\\device\\harddisk%d\\partition0"
+	CHECKSUM_TYPE_SHA256                                    = uint16(4)
+	REFS_CHECKSUM_TYPE                                      = CHECKSUM_TYPE_SHA256
+	MAX_SIZE_OF_KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS = 16 * 8 // 128 bytes
+	SIZE_OF_WCHAR                                           = int(unsafe.Sizeof(uint16(0)))
+	KERNEL_FORMAT_VOLUME_MAX_VOLUME_LABEL_LENGTH            = uint32(33 * SIZE_OF_WCHAR)
+	KERNEL_FORMAT_VOLUME_WIN32_DRIVER_PATH                  = "\\\\?\\KernelFSFormatter"
+	// Allocate large enough buffer for output from fsFormatter
+	MAX_SIZE_OF_OUTPUT_BUFFER = uint32(512)
+)
+
+type KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES uint32
+
+const (
+	KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_INVALID = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES(iota)
+	KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS    = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES(1)
+	KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_MAX     = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES(2)
+)
+
+// We only want to allow refs formatting
+func (filesystemType KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES) String() string {
+	switch filesystemType {
+	case KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS:
+		return "KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS"
+	default:
+		return "Unknown"
+	}
+}
+
+type KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS uint32
+
+const KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE = KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS(0x00000000)
+
+func (flag KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS) String() string {
+	switch flag {
+	case KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE:
+		return "KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE"
+	default:
+		return "Unknown"
+	}
+}
+
+type KernelFormatVolumeFormatRefsParameters struct {
+	ClusterSize          uint32
+	MetadataChecksumType uint16
+	UseDataIntegrity     bool
+	MajorVersion         uint16
+	MinorVersion         uint16
+}
+
+type KernelFormatVolumeFormatFsParameters struct {
+	FileSystemType KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES
+	// Represents a WCHAR character array
+	VolumeLabel [KERNEL_FORMAT_VOLUME_MAX_VOLUME_LABEL_LENGTH / uint32(SIZE_OF_WCHAR)]uint16
+	// Length of volume label in bytes
+	VolumeLabelLength uint16
+	// RefsFormatterParams represents the following union
+	/*
+	   union {
+
+	       KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS RefsParameters;
+
+	       //
+	       //  This structure can't grow in size nor change in alignment. 16 ULONGLONGs
+	       //  should be more than enough for supporting other filesystems down the
+	       //  line. This also serves to enforce 8 byte alignment.
+	       //
+	       Reserved [16]uint64
+	   };
+	*/
+	RefsFormatterParams [128]byte
+}
+
+type KernelFormatVolumeFormatInputBuffer struct {
+	Size         uint64
+	FsParameters KernelFormatVolumeFormatFsParameters
+	Flags        KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS
+	Reserved     [4]uint32
+	// Size of DiskPathBuffer in bytes
+	DiskPathLength uint16
+	// DiskPathBuffer holds the disk path. It represents a
+	// variable size WCHAR character array
+	DiskPathBuffer []uint16
+}
+
+type KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS uint32
+
+const KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAG_NONE = KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS(0x00000000)
+
+func (flag KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS) String() string {
+	switch flag {
+	case KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAG_NONE:
+		return "KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAG_NONE"
+	default:
+		return "Unknown"
+	}
+}
+
+type KernelFormarVolumeFormatOutputBuffer struct {
+	Size     uint32
+	Flags    KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS
+	Reserved [4]uint32
+	// VolumePathLength holds size of VolumePathBuffer
+	// in bytes
+	VolumePathLength uint16
+	// VolumePathBuffer holds the mounted volume path
+	// as returned from fsFormatter. It represents
+	// a variable size WCHAR character array
+	VolumePathBuffer []uint16
+}
+
+// GetVolumePathBufferOffset gets offset to KernelFormarVolumeFormatOutputBuffer{}.VolumePathBuffer
+func GetVolumePathBufferOffset() uint32 {
+	volPathBufferOffset := uint32(unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.Size) +
+		unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.Flags) +
+		unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.Reserved) +
+		unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.VolumePathLength))
+
+	return volPathBufferOffset
+}
+
+// getInputBufferSize gets the total size needed for input buffer
+func getInputBufferSize(wcharDiskPathLength uint16) uint32 {
+	bufferSize := uint32(unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Size)+
+		unsafe.Offsetof(KernelFormatVolumeFormatFsParameters{}.RefsFormatterParams)+
+		/* this is specifically for the union inKernelFormatVolumeFormatFsParameters */
+		MAX_SIZE_OF_KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS+
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Flags)+
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Reserved)+
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.DiskPathLength)) +
+		uint32(wcharDiskPathLength)
+
+	return bufferSize
+}
+
+// getInputBufferDiskPathBufferOffset gets offset to KernelFormatVolumeFormatInputBuffer{}.DiskPathBuffer
+func getInputBufferDiskPathBufferOffset() uint32 {
+	diskPathBufferOffset := uint32(unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Size) +
+		unsafe.Offsetof(KernelFormatVolumeFormatFsParameters{}.RefsFormatterParams) +
+		MAX_SIZE_OF_KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS +
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Flags) +
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Reserved) +
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.DiskPathLength))
+
+	return diskPathBufferOffset
+}
+
+// KmFmtCreateFormatOutputBuffer formats an output buffer as expected
+// by the fsFormatter driver
+func KmFmtCreateFormatOutputBuffer() *KernelFormarVolumeFormatOutputBuffer {
+	buf := make([]uint16, MAX_SIZE_OF_OUTPUT_BUFFER)
+	outputBuffer := (*KernelFormarVolumeFormatOutputBuffer)(unsafe.Pointer(&buf[0]))
+	outputBuffer.Size = uint32(MAX_SIZE_OF_OUTPUT_BUFFER)
+
+	return outputBuffer
+}
+
+// KmFmtCreateFormatInputBuffer formats an input buffer as expected
+// by the fsFormatter driver.
+// diskPath represents disk path in VirtualDevObjectPathFormat.
+func KmFmtCreateFormatInputBuffer(diskPath string) *KernelFormatVolumeFormatInputBuffer {
+	refsParametersBuf := make([]byte, unsafe.Sizeof(KernelFormatVolumeFormatRefsParameters{}))
+	refsParameters := (*KernelFormatVolumeFormatRefsParameters)(unsafe.Pointer(&refsParametersBuf[0]))
+
+	utf16DiskPath := utf16.Encode([]rune(diskPath))
+	wcharDiskPathLength := uint16(len(utf16DiskPath) * SIZE_OF_WCHAR)
+
+	refsParameters.ClusterSize = 0x1000
+	refsParameters.MetadataChecksumType = REFS_CHECKSUM_TYPE
+	refsParameters.UseDataIntegrity = true
+	refsParameters.MajorVersion = uint16(3)
+	refsParameters.MinorVersion = uint16(14)
+
+	bufferSize := getInputBufferSize(wcharDiskPathLength)
+	log.Printf("\n Input buffer size: %v bytes", bufferSize)
+	buf := make([]byte, bufferSize) // bufferSize)
+	inputBuffer := (*KernelFormatVolumeFormatInputBuffer)(unsafe.Pointer(&buf[0]))
+
+	inputBuffer.Size = uint64(bufferSize)
+	inputBuffer.Flags = KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE
+
+	inputBuffer.FsParameters.FileSystemType = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS
+	// Not setting inputBuffer.FsParameters.VolumeLabel to leave it empty
+	inputBuffer.FsParameters.VolumeLabelLength = 0 // Scratch disk need not be partitioned. Therefore pass wchar empty string.
+	inputBuffer.FsParameters.VolumeLabel = [33]uint16{}
+
+	// Write KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS
+	// Write the ClusterSize (8 bytes)
+	binary.LittleEndian.PutUint32(inputBuffer.FsParameters.RefsFormatterParams[0:], refsParameters.ClusterSize)
+	// Write the MetadataChecksumType (2 bytes)
+	binary.LittleEndian.PutUint16(inputBuffer.FsParameters.RefsFormatterParams[4:], refsParameters.MetadataChecksumType)
+	// Write the UseDataIntegrity (1 byte)
+	if refsParameters.UseDataIntegrity {
+		inputBuffer.FsParameters.RefsFormatterParams[6] = 1
+	} else {
+		inputBuffer.FsParameters.RefsFormatterParams[6] = 0
+	}
+	// Write the MajorVersion (2 bytes)
+	binary.LittleEndian.PutUint16(inputBuffer.FsParameters.RefsFormatterParams[8:], refsParameters.MajorVersion)
+	// Write the MinorVersion (2 bytes)
+	binary.LittleEndian.PutUint16(inputBuffer.FsParameters.RefsFormatterParams[10:], refsParameters.MinorVersion)
+
+	// TODO(kiashok): This can be cleaned up
+	for i := 12; i < 128; i++ {
+		inputBuffer.FsParameters.RefsFormatterParams[i] = 0 // Padding with 0s
+	}
+
+	// Finally write the diskPathLength and diskPathBuffer with the input disk path
+	inputBuffer.DiskPathLength = wcharDiskPathLength
+	// DiskBuffer writing
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(inputBuffer)) + uintptr(getInputBufferDiskPathBufferOffset()))
+	// Convert the string to UTF-16 slice
+	utf16Array := utf16.Encode([]rune(diskPath))
+	for _, val := range utf16Array {
+		*(*uint16)(ptr) = val
+		ptr = unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + uintptr(2))
+	}
+
+	return inputBuffer
+}

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -26,7 +26,10 @@ const (
 	// ResourceTypeMappedVirtualDisk is the modify resource type for mapped
 	// virtual disks
 	ResourceTypeMappedVirtualDisk guestrequest.ResourceType = "MappedVirtualDisk"
-	ResourceTypeWCOWBlockCims     guestrequest.ResourceType = "WCOWBlockCims"
+	// ResourceTypeMappedVirtualDiskForContainerScratch is the modify resource type
+	// specifically for refs formatting and mounting scratch vhds for c-wcow cases only.
+	ResourceTypeMappedVirtualDiskForContainerScratch guestrequest.ResourceType = "MappedVirtualDiskForContainerScratch"
+	ResourceTypeWCOWBlockCims                        guestrequest.ResourceType = "WCOWBlockCims"
 	// ResourceTypeNetwork is the modify resource type for the `NetworkAdapterV2`
 	// device.
 	ResourceTypeNetwork          guestrequest.ResourceType = "Network"

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -26,6 +26,7 @@ const (
 	// ResourceTypeMappedVirtualDisk is the modify resource type for mapped
 	// virtual disks
 	ResourceTypeMappedVirtualDisk guestrequest.ResourceType = "MappedVirtualDisk"
+	ResourceTypeWCOWBlockCims     guestrequest.ResourceType = "WCOWBlockCims"
 	// ResourceTypeNetwork is the modify resource type for the `NetworkAdapterV2`
 	// device.
 	ResourceTypeNetwork          guestrequest.ResourceType = "Network"
@@ -96,6 +97,18 @@ type LCOWMappedVirtualDisk struct {
 	VerityInfo       *DeviceVerityInfo `json:"VerityInfo,omitempty"`
 	EnsureFilesystem bool              `json:"EnsureFilesystem,omitempty"`
 	Filesystem       string            `json:"Filesystem,omitempty"`
+}
+
+type BlockCIMDevice struct {
+	CimName string
+	Lun     int32
+}
+
+type WCOWBlockCIMMounts struct {
+	// BlockCIMs should be ordered from merged CIM followed by Layer n .. layer 1
+	BlockCIMs  []BlockCIMDevice `json:"BlockCIMs,omitempty"`
+	VolumeGuid string           `json:"VolumeGuid,omitempty"`
+	MountFlags uint32           `json:"MountFlags,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -65,28 +65,48 @@ func NewDefaultOptionsWCOW(id, owner string) *OptionsWCOW {
 
 func (uvm *UtilityVM) startExternalGcsListener(ctx context.Context) error {
 	log.G(ctx).WithField("vmID", uvm.runtimeID).Debug("Using external GCS bridge")
-
+	/*
+		//if uvm.WCOWconfidentialUVMOptions.WCOWSecurityPolicy != "" {
+		l, err := winio.ListenHvsock(&winio.HvsockAddr{
+			// 1. TODO:
+			// Following line is only temporary for POC and ease of developement.
+			// "VMID: gcs.HV_GUID_LOOPBACK" means that we are trying to start sidecar
+			// outside of the UVM, that is in the host itself. This is only for
+			// easy developement.
+			VMID:      uvm.runtimeID,
+			ServiceID: gcs.WindowsSidecarGcsHvsockServiceID,
+			// 2. TODO:
+			// Following line can be uncommented after POC to ensure that
+			// hcsshim connects to gcs-sidecar.exe GUID and NOT to the windows GCS
+			// directly and this change should ONLY be for C-WCOW cases.
+			// We can base the decision of which GUID the external GCS listener should
+			// connect to based on annotations.WindowsSecurityPolicy annotation in pod.json.
+			// gcs.WindowsGcsHvsockServiceID,
+		})
+	*/
 	l, err := winio.ListenHvsock(&winio.HvsockAddr{
-		// 1. TODO:
-		// Following line is only temporary for POC and ease of developement.
-		// "VMID: gcs.HV_GUID_LOOPBACK" means that we are trying to start sidecar
-		// outside of the UVM, that is in the host itself. This is only for
-		// easy developement.
-		VMID: gcs.HV_GUID_LOOPBACK,
-		// ORIGINAL: uvm.runtimeID,
+		VMID: uvm.runtimeID,
+		// gcs.HV_GUID_PARENT,
 		ServiceID: gcs.WindowsSidecarGcsHvsockServiceID,
-		// 2. TODO:
-		// Following line can be uncommented after POC to ensure that
-		// hcsshim connects to gcs-sidecar.exe GUID and NOT to the windows GCS
-		// directly and this change should ONLY be for C-WCOW cases.
-		// We can base the decision of which GUID the external GCS listener should
-		// connect to based on annotations.WindowsSecurityPolicy annotation in pod.json.
-		// gcs.WindowsGcsHvsockServiceID,
+		//gcs.WindowsGcsHvsockServiceID,
 	})
 	if err != nil {
 		return err
 	}
+
 	uvm.gcListener = l
+	/*
+		} else { // non confidential case
+			l, err := winio.ListenHvsock(&winio.HvsockAddr{
+				VMID:      uvm.runtimeID,
+				ServiceID: gcs.WindowsGcsHvsockServiceID,
+			})
+			if err != nil {
+				return err
+			}
+
+			uvm.gcListener = l
+		}*/
 	return nil
 }
 
@@ -171,10 +191,7 @@ func prepareConfigDoc(ctx context.Context, uvm *UtilityVM, opts *OptionsWCOW) (*
 
 	// Temporary hack to start up windows sidecar gcs in the uvm
 	isCWCOW := true
-	/* TODO: temp only for POC/demo. Can be removed once we have pipeline work to
-	// consume gcs-sidecar.exe and bring it up as a service during boot time.
-	// Till such time, this start gcs-sidecar.exe as a service for every createPod()
-	// request.
+	/* TODO: uncomment after POC
 	if opts.WcowSecurityPolicy != "" {
 		isCWCOW = true
 	}

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -11,9 +11,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"os"
-	"os/exec"
-	"syscall"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -254,28 +251,29 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		// development. After dev work, it can be easily tested
 		// by minor tweaks to hvsockAddress to run inside the uvm
 		// + inbox gcs to listen on HV_SOCK_LOOPBACK.
-		sidecarPath := "C:\\gcs-sidecar.exe"
-		//sidecarCmd := fmt.Sprintf("%s %s", sidecarPath, uvm.runtimeID)
-		cmd := exec.Command(sidecarPath, uvm.runtimeID.String())
+		/*
+			sidecarPath := "C:\\gcs-sidecar.exe"
+			//sidecarCmd := fmt.Sprintf("%s %s", sidecarPath, uvm.runtimeID)
+			cmd := exec.Command(sidecarPath, uvm.runtimeID.String())
 
-		// Set the Pdeathsig field to 0 to prevent the subprocess from being terminated
-		// when the parent process exits
-		cmd.SysProcAttr = &syscall.SysProcAttr{
-			ParentProcess: 0,
-		}
-		// Redirect stdout to a file
-		outfile, err := os.Create("C:\\gcs-sidecar-logs-redirect.log")
-		if err != nil {
-			return fmt.Errorf("error create sidecar log file")
-		}
-		// defer outfile.Close()
-		cmd.Stdout = outfile
+			// Set the Pdeathsig field to 0 to prevent the subprocess from being terminated
+			// when the parent process exits
+			cmd.SysProcAttr = &syscall.SysProcAttr{
+				ParentProcess: 0,
+			}
+			// Redirect stdout to a file
+			outfile, err := os.Create("C:\\gcs-sidecar-logs-redirect.log")
+			if err != nil {
+				return fmt.Errorf("error create sidecar log file")
+			}
+			// defer outfile.Close()
+			cmd.Stdout = outfile
 
-		err = cmd.Start()
-		if err != nil {
-			return fmt.Errorf("failed to do start gcs-sidecar: %w", err)
-		}
-
+			err = cmd.Start()
+			if err != nil {
+				return fmt.Errorf("failed to do start gcs-sidecar: %w", err)
+			}
+		*/
 		// Accept the GCS connection.
 		conn, err := uvm.acceptAndClose(ctx, uvm.gcListener)
 		uvm.gcListener = nil

--- a/internal/wclayer/cim/mount.go
+++ b/internal/wclayer/cim/mount.go
@@ -108,7 +108,21 @@ func MergeMountBlockCIMLayer(ctx context.Context, mergedLayer *cimfs.BlockCIM, p
 	if err != nil {
 		return "", fmt.Errorf("generated cim mount GUID: %w", err)
 	}
+
+	// Assuming the call will be similar to the following:
+	//if vm == nil {
 	return cimfs.MountMergedBlockCIMs(mergedLayer, parentLayers, mountFlags, volumeGUID)
+	//	} else {
+	/*
+				// make mount request to gcs-sidecar
+		req := guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeAdd,
+		}
+
+			}
+	*/
+
 }
 
 // Unmounts the cim mounted at the given volume

--- a/internal/winapi/devices.go
+++ b/internal/winapi/devices.go
@@ -4,6 +4,8 @@ package winapi
 
 import "github.com/Microsoft/go-winio/pkg/guid"
 
+//sys CMGetDeviceInterfaceListSize(listlen *uint32, classGUID *g, deviceID *uint16, ulFlags uint32) (hr error) = cfgmgr32.CM_Get_Device_Interface_List_SizeW
+//sys CMGetDeviceInterfaceList(classGUID *g, deviceID *uint16, buffer *uint16, bufLen uint32, ulFlags uint32) (hr error) = cfgmgr32.CM_Get_Device_Interface_ListW
 //sys CMGetDeviceIDListSize(pulLen *uint32, pszFilter *byte, uFlags uint32) (hr error) = cfgmgr32.CM_Get_Device_ID_List_SizeA
 //sys CMGetDeviceIDList(pszFilter *byte, buffer *byte, bufferLen uint32, uFlags uint32) (hr error)= cfgmgr32.CM_Get_Device_ID_ListA
 //sys CMLocateDevNode(pdnDevInst *uint32, pDeviceID string, uFlags uint32) (hr error) = cfgmgr32.CM_Locate_DevNodeW

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -52,6 +52,8 @@ var (
 	procCM_Get_DevNode_PropertyW               = modcfgmgr32.NewProc("CM_Get_DevNode_PropertyW")
 	procCM_Get_Device_ID_ListA                 = modcfgmgr32.NewProc("CM_Get_Device_ID_ListA")
 	procCM_Get_Device_ID_List_SizeA            = modcfgmgr32.NewProc("CM_Get_Device_ID_List_SizeA")
+	procCM_Get_Device_Interface_ListW          = modcfgmgr32.NewProc("CM_Get_Device_Interface_ListW")
+	procCM_Get_Device_Interface_List_SizeW     = modcfgmgr32.NewProc("CM_Get_Device_Interface_List_SizeW")
 	procCM_Locate_DevNodeW                     = modcfgmgr32.NewProc("CM_Locate_DevNodeW")
 	procCimAddFsToMergedImage                  = modcimfs.NewProc("CimAddFsToMergedImage")
 	procCimAddFsToMergedImage2                 = modcimfs.NewProc("CimAddFsToMergedImage2")
@@ -158,6 +160,28 @@ func CMGetDeviceIDList(pszFilter *byte, buffer *byte, bufferLen uint32, uFlags u
 
 func CMGetDeviceIDListSize(pulLen *uint32, pszFilter *byte, uFlags uint32) (hr error) {
 	r0, _, _ := syscall.SyscallN(procCM_Get_Device_ID_List_SizeA.Addr(), uintptr(unsafe.Pointer(pulLen)), uintptr(unsafe.Pointer(pszFilter)), uintptr(uFlags))
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func CMGetDeviceInterfaceList(classGUID *g, deviceID *uint16, buffer *uint16, bufLen uint32, ulFlags uint32) (hr error) {
+	r0, _, _ := syscall.SyscallN(procCM_Get_Device_Interface_ListW.Addr(), uintptr(unsafe.Pointer(classGUID)), uintptr(unsafe.Pointer(deviceID)), uintptr(unsafe.Pointer(buffer)), uintptr(bufLen), uintptr(ulFlags))
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func CMGetDeviceInterfaceListSize(listlen *uint32, classGUID *g, deviceID *uint16, ulFlags uint32) (hr error) {
+	r0, _, _ := syscall.SyscallN(procCM_Get_Device_Interface_List_SizeW.Addr(), uintptr(unsafe.Pointer(listlen)), uintptr(unsafe.Pointer(classGUID)), uintptr(unsafe.Pointer(deviceID)), uintptr(ulFlags))
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -15,6 +15,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const (
+	VolumePathFormat = "\\\\?\\Volume{%s}\\"
+)
+
 type MountError struct {
 	Cim        string
 	Op         string
@@ -116,5 +120,5 @@ func MountMergedBlockCIMs(mergedCIM *BlockCIM, sourceCIMs []*BlockCIM, mountFlag
 	if err := winapi.CimMergeMountImage(uint32(len(cimsToMerge)), &cimsToMerge[0], mountFlags, &volumeGUID); err != nil {
 		return "", &MountError{Cim: filepath.Join(mergedCIM.BlockPath, mergedCIM.CimName), Op: "MountMerged", Err: err}
 	}
-	return fmt.Sprintf("\\\\?\\Volume{%s}\\", volumeGUID.String()), nil
+	return fmt.Sprintf(VolumePathFormat, volumeGUID.String()), nil
 }


### PR DESCRIPTION
Includes commits to run sidecar inside UVM + code cleanup + refs tool that invokes fsFormatter driver through ioctl call. Confirmed that the disk is being refs formatted.