### PR TITLE
C-WCOW: Merge securitypolicy package for linux and windows

### DIFF
--- a/cmd/gcs-sidecar/internal/bridge/bridge.go
+++ b/cmd/gcs-sidecar/internal/bridge/bridge.go
@@ -15,8 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/windows"
 
-	"github.com/Microsoft/hcsshim/cmd/gcs-sidecar/internal/windowssecuritypolicy"
 	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
+	windowssecuritypolicy "github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 // TODO:

--- a/cmd/gcs-sidecar/internal/bridge/handlers.go
+++ b/cmd/gcs-sidecar/internal/bridge/handlers.go
@@ -10,11 +10,11 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/Microsoft/hcsshim/cmd/gcs-sidecar/internal/windowssecuritypolicy"
 	"github.com/Microsoft/hcsshim/hcn"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	windowssecuritypolicy "github.com/Microsoft/hcsshim/pkg/securitypolicy"
 	"github.com/pkg/errors"
 )
 

--- a/cmd/gcs-sidecar/internal/bridge/policy_helpers.go
+++ b/cmd/gcs-sidecar/internal/bridge/policy_helpers.go
@@ -8,10 +8,10 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/Microsoft/hcsshim/cmd/gcs-sidecar/internal/windowssecuritypolicy"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	windowssecuritypolicy "github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 func (s *SecurityPoliyEnforcer) SetWCOWConfidentialUVMOptions(securityPolicyRequest *guestresource.WCOWConfidentialOptions) error {

--- a/cmd/gcs-sidecar/main.go
+++ b/cmd/gcs-sidecar/main.go
@@ -17,7 +17,7 @@ import (
 	"golang.org/x/sys/windows/svc/debug"
 
 	gcsBridge "github.com/Microsoft/hcsshim/cmd/gcs-sidecar/internal/bridge"
-	"github.com/Microsoft/hcsshim/cmd/gcs-sidecar/internal/windowssecuritypolicy"
+	windowssecuritypolicy "github.com/Microsoft/hcsshim/pkg/securitypolicy"
 )
 
 type handler struct {

--- a/pkg/securitypolicy/securitypolicy_test.go
+++ b/pkg/securitypolicy/securitypolicy_test.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package securitypolicy
 
 import (

--- a/pkg/securitypolicy/securitypolicy_uvmpath_linux.go
+++ b/pkg/securitypolicy/securitypolicy_uvmpath_linux.go
@@ -1,0 +1,35 @@
+//go:build linux
+// +build linux
+
+package securitypolicy
+
+import (
+	"strings"
+
+	"github.com/Microsoft/hcsshim/internal/guest/spec"
+	specInternal "github.com/Microsoft/hcsshim/internal/guest/spec"
+	"github.com/Microsoft/hcsshim/internal/guestpath"
+)
+
+// This is being used by StandEnforcer.
+// substituteUVMPath substitutes mount prefix to an appropriate path inside
+// UVM. At policy generation time, it's impossible to tell what the sandboxID
+// will be, so the prefix substitution needs to happen during runtime.
+func substituteUVMPath(sandboxID string, m mountInternal) mountInternal {
+	if strings.HasPrefix(m.Source, guestpath.SandboxMountPrefix) {
+		m.Source = specInternal.SandboxMountSource(sandboxID, m.Source)
+	} else if strings.HasPrefix(m.Source, guestpath.HugePagesMountPrefix) {
+		m.Source = specInternal.HugePagesMountSource(sandboxID, m.Source)
+	}
+	return m
+}
+
+// SandboxMountsDir returns sandbox mounts directory inside UVM/host.
+func SandboxMountsDir(sandboxID string) string {
+	return spec.SandboxMountsDir((sandboxID))
+}
+
+// HugePagesMountsDir returns hugepages mounts directory inside UVM.
+func HugePagesMountsDir(sandboxID string) string {
+	return spec.HugePagesMountsDir(sandboxID)
+}

--- a/pkg/securitypolicy/securitypolicy_uvmpath_windows.go
+++ b/pkg/securitypolicy/securitypolicy_uvmpath_windows.go
@@ -1,0 +1,24 @@
+//go:build windows
+// +build windows
+
+package securitypolicy
+
+// This is being used by StandEnforcer and is a no-op for windows.
+// substituteUVMPath substitutes mount prefix to an appropriate path inside
+// UVM. At policy generation time, it's impossible to tell what the sandboxID
+// will be, so the prefix substitution needs to happen during runtime.
+func substituteUVMPath(sandboxID string, m mountInternal) mountInternal {
+	//no-op for windows
+	_ = sandboxID
+	return m
+}
+
+// SandboxMountsDir returns sandbox mounts directory inside UVM/host.
+func SandboxMountsDir(sandboxID string) string {
+	return ""
+}
+
+// HugePagesMountsDir returns hugepages mounts directory inside UVM.
+func HugePagesMountsDir(sandboxID string) string {
+	return ""
+}

--- a/pkg/securitypolicy/securitypolicyenforcer.go
+++ b/pkg/securitypolicy/securitypolicyenforcer.go
@@ -1,6 +1,3 @@
-//go:build linux
-// +build linux
-
 package securitypolicy
 
 import (
@@ -10,14 +7,11 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
-	"strings"
 	"sync"
 	"syscall"
 
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 
-	specInternal "github.com/Microsoft/hcsshim/internal/guest/spec"
-	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/pkg/errors"
 )
 
@@ -854,18 +848,6 @@ func (c *securityPolicyContainer) matchMount(sandboxID string, m oci.Mount) (err
 		}
 	}
 	return fmt.Errorf("mount is not allowed by policy: %+v", m)
-}
-
-// substituteUVMPath substitutes mount prefix to an appropriate path inside
-// UVM. At policy generation time, it's impossible to tell what the sandboxID
-// will be, so the prefix substitution needs to happen during runtime.
-func substituteUVMPath(sandboxID string, m mountInternal) mountInternal {
-	if strings.HasPrefix(m.Source, guestpath.SandboxMountPrefix) {
-		m.Source = specInternal.SandboxMountSource(sandboxID, m.Source)
-	} else if strings.HasPrefix(m.Source, guestpath.HugePagesMountPrefix) {
-		m.Source = specInternal.HugePagesMountSource(sandboxID, m.Source)
-	}
-	return m
 }
 
 func stringSlicesEqual(slice1, slice2 []string) bool {

--- a/pkg/securitypolicy/securitypolicyenforcer_rego.go
+++ b/pkg/securitypolicy/securitypolicyenforcer_rego.go
@@ -1,5 +1,5 @@
-//go:build linux && rego
-// +build linux,rego
+//go:build rego
+// +build rego
 
 package securitypolicy
 
@@ -15,11 +15,10 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Microsoft/hcsshim/internal/guest/spec"
 	"github.com/Microsoft/hcsshim/internal/guestpath"
 	"github.com/Microsoft/hcsshim/internal/log"
 	rpi "github.com/Microsoft/hcsshim/internal/regopolicyinterpreter"
-	"github.com/opencontainers/runc/libcontainer/user"
+	"github.com/moby/sys/user"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
 )
@@ -719,8 +718,8 @@ func (policy *regoEnforcer) EnforceCreateContainerPolicy(
 		"argList":              argList,
 		"envList":              envList,
 		"workingDir":           workingDir,
-		"sandboxDir":           spec.SandboxMountsDir(sandboxID),
-		"hugePagesDir":         spec.HugePagesMountsDir(sandboxID),
+		"sandboxDir":           SandboxMountsDir(sandboxID),
+		"hugePagesDir":         HugePagesMountsDir(sandboxID),
 		"mounts":               appendMountData([]interface{}{}, mounts),
 		"privileged":           privileged,
 		"noNewPrivileges":      noNewPrivileges,


### PR DESCRIPTION
- Move uvm path function to handle both Linux and Windows
- Update code to use existing securitypolicy package