### PR TITLE
Code cleanup and refactor

### DIFF
--- a/cmd/gcs-sidecar/internal/bridge/uvm.go
+++ b/cmd/gcs-sidecar/internal/bridge/uvm.go
@@ -1,0 +1,156 @@
+package bridge
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/Microsoft/hcsshim/internal/guest/commonutils"
+	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
+	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	windowssecuritypolicy "github.com/Microsoft/hcsshim/pkg/securitypolicy"
+	"github.com/pkg/errors"
+)
+
+func modifyCombinedLayers(
+	ctx context.Context,
+	containerID string,
+	rt guestrequest.RequestType,
+	cl guestresource.WCOWCombinedLayers,
+	securityPolicy windowssecuritypolicy.SecurityPolicyEnforcer,
+) (err error) {
+	switch rt {
+	case guestrequest.RequestTypeAdd:
+		layerPaths := make([]string, len(cl.Layers))
+		for i, layer := range cl.Layers {
+			layerPaths[i] = layer.Path
+			//TODO: Remove this when there is verified Cimfs API. This only here to mock
+			// mount device
+			log.Printf("enforcing mount_device in combinedlayers: %v, %v", layer.Path, layer.Id)
+			securityPolicy.EnforceDeviceMountPolicy(ctx, layer.Path, layer.Id)
+		}
+		log.Printf("enforcing mount_overlay in combinedlayers")
+		return securityPolicy.EnforceOverlayMountPolicy(ctx, containerID, layerPaths, cl.ContainerRootPath)
+	case guestrequest.RequestTypeRemove:
+		return securityPolicy.EnforceOverlayUnmountPolicy(ctx, cl.ContainerRootPath)
+	default:
+		return newInvalidRequestTypeError(rt)
+	}
+}
+
+func newInvalidRequestTypeError(rt guestrequest.RequestType) error {
+	return errors.Errorf("the RequestType %q is not supported", rt)
+}
+
+func modifyMappedVirtualDisk(
+	ctx context.Context,
+	rt guestrequest.RequestType,
+	mvd *guestresource.WCOWMappedVirtualDisk,
+	securityPolicy windowssecuritypolicy.SecurityPolicyEnforcer,
+) (err error) {
+	switch rt {
+	case guestrequest.RequestTypeAdd:
+		// TODO: Modify and update this with verified Cims API
+		return securityPolicy.EnforceDeviceMountPolicy(ctx, mvd.ContainerPath, "hash")
+	case guestrequest.RequestTypeRemove:
+		// TODO: Modify and update this with verified Cims API
+		return securityPolicy.EnforceDeviceUnmountPolicy(ctx, mvd.ContainerPath)
+	default:
+		return newInvalidRequestTypeError(rt)
+	}
+}
+
+func unmarshalContainerModifySettings(req *request) (*containerModifySettings, error) {
+	var r containerModifySettings
+	var requestRawSettings json.RawMessage
+	r.Request = &requestRawSettings
+	if err := commonutils.UnmarshalJSONWithHresult(req.message, &r); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal rpcModifySettings: %v", req)
+	}
+
+	var modifyGuestSettingsRequest guestrequest.ModificationRequest
+	var rawGuestRequest json.RawMessage
+	modifyGuestSettingsRequest.Settings = &rawGuestRequest
+	if err := commonutils.UnmarshalJSONWithHresult(requestRawSettings, &modifyGuestSettingsRequest); err != nil {
+		log.Printf("invalid rpcModifySettings ModificationRequest request %v", r)
+		return nil, fmt.Errorf("invalid rpcModifySettings ModificationRequest request %v", r)
+	}
+	log.Printf("rpcModifySettings: ModificationRequest %v\n", modifyGuestSettingsRequest)
+
+	if modifyGuestSettingsRequest.RequestType == "" {
+		modifyGuestSettingsRequest.RequestType = guestrequest.RequestTypeAdd
+	}
+
+	switch modifyGuestSettingsRequest.ResourceType {
+	case guestresource.ResourceTypeCWCOWCombinedLayers:
+
+		settings := &guestresource.CWCOWCombinedLayers{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, settings); err != nil {
+			log.Printf("invalid ResourceTypeCombinedLayers request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeCombinedLayers request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = settings
+
+	case guestresource.ResourceTypeCombinedLayers:
+		settings := &guestresource.WCOWCombinedLayers{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, settings); err != nil {
+			log.Printf("invalid ResourceTypeCombinedLayers request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeCombinedLayers request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = settings
+
+	case guestresource.ResourceTypeNetworkNamespace:
+		settings := &hcn.HostComputeNamespace{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, settings); err != nil {
+			log.Printf("invalid ResourceTypeNetworkNamespace request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeNetworkNamespace request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = settings
+
+	case guestresource.ResourceTypeNetwork:
+		// following valid only for osversion.Build() >= osversion.RS5
+		// since Cwcow is available only for latest versions this is ok
+		// TODO: Check if osversion >= rs5 else error out
+		settings := &guestrequest.NetworkModifyRequest{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, settings); err != nil {
+			log.Printf("invalid ResourceTypeNetwork request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeNetwork request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = settings
+
+	case guestresource.ResourceTypeMappedVirtualDisk:
+		wcowMappedVirtualDisk := &guestresource.WCOWMappedVirtualDisk{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, wcowMappedVirtualDisk); err != nil {
+			log.Printf("invalid ResourceTypeMappedVirtualDisk request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeMappedVirtualDisk request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = wcowMappedVirtualDisk
+		log.Printf(", wcowMappedVirtualDisk { %v} \n", wcowMappedVirtualDisk)
+
+	case guestresource.ResourceTypeHvSocket:
+		hvSocketAddress := &hcsschema.HvSocketAddress{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, hvSocketAddress); err != nil {
+			log.Printf("invalid ResourceTypeHvSocket request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeHvSocket request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = hvSocketAddress
+
+	case guestresource.ResourceTypeSecurityPolicy:
+		securityPolicyRequest := &guestresource.WCOWConfidentialOptions{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, securityPolicyRequest); err != nil {
+			log.Printf("invalid ResourceTypeSecurityPolicy request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeSecurityPolicy request %v", r)
+		}
+		modifyGuestSettingsRequest.Settings = securityPolicyRequest
+
+	default:
+		// Invalid request
+		log.Printf("\n Invald modifySettingsRequest: %v", modifyGuestSettingsRequest.ResourceType)
+		return nil, fmt.Errorf("invald modifySettingsRequest: %v", modifyGuestSettingsRequest.ResourceType)
+	}
+	r.Request = &modifyGuestSettingsRequest
+	return &r, nil
+}

--- a/cmd/gcs-sidecar/main.go
+++ b/cmd/gcs-sidecar/main.go
@@ -214,6 +214,11 @@ func main() {
 		return
 	}
 
+	// TODO:
+	// Since gcs-sidecar can be used for all types of windows
+	// containers, it is important to check if we want to
+	// enforce policy or not. Therefore do we want to have
+	// an initialState?
 	// set up our initial stance policy enforcer
 	var initialEnforcer windowssecuritypolicy.SecurityPolicyEnforcer
 	initialPolicyStance := "allow"
@@ -229,14 +234,12 @@ func main() {
 	}
 
 	// 3. Create bridge and initializa
-	brdg := gcsBridge.NewBridge(shimCon, gcsCon)
-	brdg.PolicyEnforcer = gcsBridge.NewPolicyEnforcer(initialEnforcer)
+	brdg := gcsBridge.NewBridge(shimCon, gcsCon, initialEnforcer)
 	brdg.AssignHandlers()
 
 	// 3. Listen and serve for hcsshim requests.
-	// startSendAndRecvLoops(shimCon, gcsCon)
 	err = brdg.ListenAndServeShimRequests()
 	if err != nil {
-		log.Printf("failed to serve gcs service \n")
+		log.Printf("\n failed to serve request: %v", err)
 	}
 }

--- a/internal/guest/prot/protocol.go
+++ b/internal/guest/prot/protocol.go
@@ -5,13 +5,17 @@ package prot
 
 import (
 	"encoding/json"
+	"fmt"
+	"math"
 	"strconv"
 
 	v1 "github.com/containerd/cgroups/v3/cgroup1/stats"
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	"github.com/Microsoft/hcsshim/internal/guest/commonutils"
+	"github.com/Microsoft/hcsshim/internal/guest/gcserr"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
@@ -827,4 +831,49 @@ type Properties struct {
 type PropertiesV2 struct {
 	ProcessList []ProcessDetails `json:"ProcessList,omitempty"`
 	Metrics     *v1.Metrics      `json:"LCOWMetrics,omitempty"`
+}
+
+// SetErrorForResponseBase modifies the passed-in MessageResponseBase to
+// contain information pertaining to the given error.
+func SetErrorForResponseBase(response *MessageResponseBase, errForResponse error, moduleName string) {
+	errorMessage := errForResponse.Error()
+	stackString := ""
+	fileName := ""
+	// We use -1 as a sentinel if no line number found (or it cannot be parsed),
+	// but that will ultimately end up as [math.MaxUint32], so set it to that explicitly.
+	// (Still keep using -1 for backwards compatibility ...)
+	lineNumber := uint32(math.MaxUint32)
+	functionName := ""
+	if stack := gcserr.BaseStackTrace(errForResponse); stack != nil {
+		bottomFrame := stack[0]
+		stackString = fmt.Sprintf("%+v", stack)
+		fileName = fmt.Sprintf("%s", bottomFrame)
+		lineNumberStr := fmt.Sprintf("%d", bottomFrame)
+		if n, err := strconv.ParseUint(lineNumberStr, 10, 32); err == nil {
+			lineNumber = uint32(n)
+		} else {
+			logrus.WithFields(logrus.Fields{
+				"line-number":   lineNumberStr,
+				logrus.ErrorKey: err,
+			}).Error("opengcs::bridge::setErrorForResponseBase - failed to parse line number, using -1 instead")
+		}
+		functionName = fmt.Sprintf("%n", bottomFrame)
+	}
+	hresult, err := gcserr.GetHresult(errForResponse)
+	if err != nil {
+		// Default to using the generic failure HRESULT.
+		hresult = gcserr.HrFail
+	}
+	response.Result = int32(hresult)
+	response.ErrorMessage = errorMessage
+	newRecord := ErrorRecord{
+		Result:       int32(hresult),
+		Message:      errorMessage,
+		StackTrace:   stackString,
+		ModuleName:   moduleName,
+		FileName:     fileName,
+		Line:         lineNumber,
+		FunctionName: functionName,
+	}
+	response.ErrorRecords = append(response.ErrorRecords, newRecord)
 }


### PR DESCRIPTION
- Updates gcs-sidecar code to make it suitable for HPC implementation in hyperv
wcow cases
- Keeps sidecar code as similar to opengcs as possible
- Since we have plans to run the gcs-sidecar for non cwcow cases as well, make sure that the secirity policy checks kick in only for cwcow.