### PR TITLE
Modidy and cherry-pick from cwcow-inside-uvm

### DIFF
--- a/cmd/gcs-sidecar/internal/bridge/bridge.go
+++ b/cmd/gcs-sidecar/internal/bridge/bridge.go
@@ -252,7 +252,7 @@ func (b *Bridge) ListenAndServeShimRequests() error {
 			var msgBase requestBase
 			_ = json.Unmarshal(msg, &msgBase)
 			req := request{
-				// ctx
+				ctx:        context.Background(),
 				activityID: msgBase.ActivityID,
 				header:     header,
 				message:    msg,

--- a/cmd/gcs-sidecar/internal/bridge/handlers.go
+++ b/cmd/gcs-sidecar/internal/bridge/handlers.go
@@ -4,15 +4,25 @@
 package bridge
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/Microsoft/hcsshim/hcn"
+	"github.com/Microsoft/hcsshim/internal/fsformatter"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/Microsoft/hcsshim/internal/protocol/guestresource"
+	"github.com/Microsoft/hcsshim/internal/windevice"
+	"github.com/Microsoft/hcsshim/pkg/cimfs"
 	"github.com/pkg/errors"
+)
+
+const (
+	sandboxStateDirName = "WcSandboxState"
+	hivesDirName        = "Hives"
 )
 
 // - Current intent of these handler functions is to call the security policy
@@ -255,37 +265,6 @@ func (b *Bridge) modifySettings(req *request) error {
 
 	if guestResourceType != "" {
 		switch guestResourceType {
-		case guestresource.ResourceTypeCWCOWCombinedLayers:
-			settings := modifyGuestSettingsRequest.Settings.(*guestresource.CWCOWCombinedLayers)
-			containerID := settings.ContainerID
-			log.Printf(", CWCOWCombinedLayers {ContainerID: %v {ContainerRootPath: %v, Layers: %v, ScratchPath: %v}} \n",
-				containerID, settings.CombinedLayers.ContainerRootPath, settings.CombinedLayers.Layers, settings.CombinedLayers.ScratchPath)
-
-			// TODO: Update modifyCombinedLayers with verified CimFS API
-			if b.hostState.isSecurityPolicyEnforcerInitialized() {
-				policy_err := modifyCombinedLayers(req.ctx, containerID, guestRequestType, settings.CombinedLayers, b.hostState.securityPolicyEnforcer)
-				if policy_err != nil {
-					return fmt.Errorf("CimFS layer mount is denied by policy: %v", modifyRequest)
-				}
-			}
-
-			// Reconstruct WCOWCombinedLayers{} and req before forwarding to GCS
-			// as GCS does not understand containerID in CombinedLayers request
-			modifyGuestSettingsRequest.ResourceType = guestresource.ResourceTypeCombinedLayers
-			modifyGuestSettingsRequest.Settings = settings.CombinedLayers
-			modifyRequest.Request = modifyGuestSettingsRequest
-			buf, err := json.Marshal(modifyRequest)
-			if err != nil {
-				return fmt.Errorf("failed to marshal rpcModifySettings: %v", req)
-			}
-
-			var newRequest request
-			newRequest.header = req.header
-			size := uint32(len(buf)) + hdrSize
-			newRequest.header.Size = size
-			newRequest.message = buf
-			req = &newRequest
-
 		case guestresource.ResourceTypeCombinedLayers:
 			settings := modifyGuestSettingsRequest.Settings.(*guestresource.WCOWCombinedLayers)
 			log.Printf(", WCOWCombinedLayers {ContainerRootPath: %v, Layers: %v, ScratchPath: %v} \n", settings.ContainerRootPath, settings.Layers, settings.ScratchPath)
@@ -324,6 +303,170 @@ func (b *Bridge) modifySettings(req *request) error {
 				return fmt.Errorf("error sending early reply back to hcsshim")
 			}
 			return nil
+
+		case guestresource.ResourceTypeWCOWBlockCims:
+			// This is request to mount the merged cim at given volumeGUID
+			wcowBlockCimMounts := modifyGuestSettingsRequest.Settings.(*guestresource.WCOWBlockCIMMounts)
+			log.Printf(", WCOWBlockCIMMounts { %v} \n", wcowBlockCimMounts)
+
+			var mergedCim cimfs.BlockCIM
+			var sourceCims []*cimfs.BlockCIM
+			ctx := context.Background()
+			for i, blockCimDevice := range wcowBlockCimMounts.BlockCIMs {
+				// Get the scsi device path for the blockCim lun
+				scsiDevPath, _, err := windevice.GetScsiDevicePathAndDiskNumberFromControllerLUN(
+					ctx,
+					0, /* controller is always 0 for wcow */
+					uint8(blockCimDevice.Lun))
+				if err != nil {
+					log.Printf("err getting scsiDevPath: %v", err)
+					return err
+				}
+				if i == 0 {
+					// BlockCIMs should be ordered from merged CIM followed by Layer n .. layer 1
+					mergedCim = cimfs.BlockCIM{
+						Type:      cimfs.BlockCIMTypeDevice,
+						BlockPath: scsiDevPath,
+						CimName:   blockCimDevice.CimName,
+					}
+				} else {
+					layerCim := cimfs.BlockCIM{
+						Type:      cimfs.BlockCIMTypeDevice,
+						BlockPath: scsiDevPath,
+						CimName:   blockCimDevice.CimName,
+					}
+					sourceCims = append(sourceCims, &layerCim)
+				}
+			}
+
+			// Get the topmost merge CIM and invoke the MountMergedBlockCIMs
+			_, err := cimfs.MountMergedBlockCIMs(&mergedCim, sourceCims, wcowBlockCimMounts.MountFlags, wcowBlockCimMounts.VolumeGuid)
+			if err != nil {
+				return fmt.Errorf("error mounting merged block cims: %v", err)
+			}
+			// Send response back to shim
+			resp := &responseBase{
+				Result:     0, // 0 means success
+				ActivityID: req.activityID,
+			}
+			err = b.sendResponseToShim(rpcModifySettings, req.header.ID, resp)
+			if err != nil {
+				log.Printf("error sending response to hcsshim: %v", err)
+				return fmt.Errorf("error sending early reply back to hcsshim")
+			}
+			return nil
+
+		case guestresource.ResourceTypeCWCOWCombinedLayers:
+			settings := modifyGuestSettingsRequest.Settings.(*guestresource.CWCOWCombinedLayers)
+			containerID := settings.ContainerID
+			log.Printf(", CWCOWCombinedLayers {ContainerID: %v {ContainerRootPath: %v, Layers: %v, ScratchPath: %v}} \n",
+				containerID, settings.CombinedLayers.ContainerRootPath, settings.CombinedLayers.Layers, settings.CombinedLayers.ScratchPath)
+
+			// TODO: Update modifyCombinedLayers with verified CimFS API
+			if b.hostState.isSecurityPolicyEnforcerInitialized() {
+				policy_err := modifyCombinedLayers(req.ctx, containerID, guestRequestType, settings.CombinedLayers, b.hostState.securityPolicyEnforcer)
+				if policy_err != nil {
+					return fmt.Errorf("CimFS layer mount is denied by policy: %v", modifyRequest)
+				}
+			}
+
+			// Reconstruct WCOWCombinedLayers{} and req before forwarding to GCS
+			// as GCS does not understand containerID in CombinedLayers request
+			modifyGuestSettingsRequest.ResourceType = guestresource.ResourceTypeCombinedLayers
+			modifyGuestSettingsRequest.Settings = settings.CombinedLayers
+			modifyRequest.Request = modifyGuestSettingsRequest
+			buf, err := json.Marshal(modifyRequest)
+			if err != nil {
+				return fmt.Errorf("failed to marshal rpcModifySettings: %v", req)
+			}
+
+			/* NOTE: The following is being commented out ONLY because this commit
+			is being cherry-picked from cwcow-inside-uvm branch to c-wcow-dev
+			on github.com/MahatiC/hcsshim. The following changes are relevant only
+			when running gcs-sidecar.exe is being run inside the uvm.
+			Since Mahati prefers the gcs-sidecar.exe to run outside the uvm for
+			policy development, this is being done to keep the two branches
+			(c-wcow-dev and cwcow-inside-uvm) in sync with latest updates from each other.
+
+				// The following two folders are expected to be present in thr scratch.
+				// But since we have just formatted the scratch we would need to
+				// create them manually.
+				sandboxStateDirectory := filepath.Join(settings.CombinedLayers.ContainerRootPath, sandboxStateDirName)
+				err = os.Mkdir(sandboxStateDirectory, 0777)
+				if err != nil {
+					log.Printf("unexpected error creating sandboxStateDirectory: %v", err)
+					return fmt.Errorf("unexpected error sandboxStateDirectory: %v", err)
+				}
+
+				hivesDirectory := filepath.Join(settings.CombinedLayers.ContainerRootPath, hivesDirName)
+				err = os.Mkdir(hivesDirectory, 0777)
+				if err != nil {
+					log.Printf("unexpected error creating hivesDirectory: %v", err)
+					return fmt.Errorf("unexpected error hivesDirectory: %v", err)
+				}
+			*/
+			var newRequest request
+			newRequest.header = req.header
+			newRequest.header.Size = uint32(len(buf)) + hdrSize
+			newRequest.message = buf
+			req = &newRequest
+
+		case guestresource.ResourceTypeMappedVirtualDiskForContainerScratch:
+			wcowMappedVirtualDisk := modifyGuestSettingsRequest.Settings.(*guestresource.WCOWMappedVirtualDisk)
+			log.Printf(", wcowMappedVirtualDisk { %v} \n", wcowMappedVirtualDisk)
+
+			// 1.TODO: Need to enforce policy before calling into fsFormatter
+			// 2. Then call fsFormatter to format the scratch disk.
+			// This will return the volume path of the mounted scratch.
+			// Scratch disk should be >= 30 GB for refs formatter to work.
+
+			// fsFormatter understands only virtualDevObjectPathFormat. Therefore fetch the
+			// disk number for the corresponding lun
+			var diskNumber uint64
+			// It could take a few seconds for the attached scsi disk
+			// to show up inside the UVM. Therefore adding retry logic
+			// with delay here.
+			for i := 0; i < 5; i++ {
+				time.Sleep(5 * time.Second)
+				_, diskNumber, err := windevice.GetScsiDevicePathAndDiskNumberFromControllerLUN(req.ctx,
+					0, /* Only one controller allowed in wcow hyperv */
+					uint8(wcowMappedVirtualDisk.Lun))
+				if err != nil {
+					if i == 4 {
+						// bail out
+						log.Printf("error getting diskNumber for LUN %d, err : %v", wcowMappedVirtualDisk.Lun, err)
+						return fmt.Errorf("error getting diskNumber for LUN %d", wcowMappedVirtualDisk.Lun)
+					}
+					continue
+				} else {
+					log.Printf("DiskNumber of lun %d is:  %d", wcowMappedVirtualDisk.Lun, diskNumber)
+				}
+			}
+			diskPath := fmt.Sprintf(fsformatter.VirtualDevObjectPathFormat, diskNumber)
+			log.Printf("\n diskPath: %v, diskNumber: %v ", diskPath, diskNumber)
+			mountedVolumePath, err := windevice.InvokeFsFormatter(req.ctx, diskPath)
+			if err != nil {
+				log.Printf("\n InvokeFsFormatter returned err: %v", err)
+				return err
+			}
+			log.Printf("\n mountedVolumePath returned from InvokeFsFormatter: %v", mountedVolumePath)
+
+			// Just forward the req as is to inbox gcs and let it retreive the volume.
+			// While forwarding request to inbox gcs, make sure to replace
+			// the resourceType to ResourceTypeMappedVirtualDisk that it
+			// understands.
+			modifyGuestSettingsRequest.ResourceType = guestresource.ResourceTypeMappedVirtualDisk
+			modifyRequest.Request = modifyGuestSettingsRequest
+			buf, err := json.Marshal(modifyRequest)
+			if err != nil {
+				return fmt.Errorf("failed to marshal rpcModifySettings: %v", req)
+			}
+
+			var newRequest request
+			newRequest.header = req.header
+			newRequest.header.Size = uint32(len(buf))
+			newRequest.message = buf
+			req = &newRequest
 
 		default:
 			// Invalid request

--- a/cmd/gcs-sidecar/internal/bridge/policy.go
+++ b/cmd/gcs-sidecar/internal/bridge/policy.go
@@ -7,16 +7,13 @@ import (
 	oci "github.com/opencontainers/runtime-spec/specs-go"
 )
 
-
 // DefaultCRIMounts returns default mounts added to windows spec by containerD.
 func DefaultCRIMounts() []oci.Mount {
-	return []oci.Mount{
-	}
+	return []oci.Mount{}
 }
 
 // DefaultCRIPrivilegedMounts returns a slice of mounts which are added to the
 // windows container spec when a container runs in a privileged mode.
 func DefaultCRIPrivilegedMounts() []oci.Mount {
-	return []oci.Mount{
-	}
+	return []oci.Mount{}
 }

--- a/cmd/gcs-sidecar/internal/bridge/uvm.go
+++ b/cmd/gcs-sidecar/internal/bridge/uvm.go
@@ -146,6 +146,20 @@ func unmarshalContainerModifySettings(req *request) (*containerModifySettings, e
 		}
 		modifyGuestSettingsRequest.Settings = securityPolicyRequest
 
+	case guestresource.ResourceTypeMappedVirtualDiskForContainerScratch:
+		wcowMappedVirtualDisk := &guestresource.WCOWMappedVirtualDisk{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, wcowMappedVirtualDisk); err != nil {
+			log.Printf("invalid ResourceTypeMappedVirtualDisk request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeMappedVirtualDisk request %v", r)
+		}
+
+	case guestresource.ResourceTypeWCOWBlockCims:
+		wcowBlockCimMounts := &guestresource.WCOWBlockCIMMounts{}
+		if err := commonutils.UnmarshalJSONWithHresult(rawGuestRequest, wcowBlockCimMounts); err != nil {
+			log.Printf("invalid ResourceTypeWCOWBlockCims request %v", r)
+			return nil, fmt.Errorf("invalid ResourceTypeWCOWBlockCims request %v", r)
+		}
+
 	default:
 		// Invalid request
 		log.Printf("\n Invald modifySettingsRequest: %v", modifyGuestSettingsRequest.ResourceType)

--- a/cmd/refs-util/main.go
+++ b/cmd/refs-util/main.go
@@ -1,0 +1,61 @@
+//go:build windows
+// +build windows
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+
+	"github.com/Microsoft/hcsshim/internal/fsformatter"
+	"github.com/Microsoft/hcsshim/internal/windevice"
+)
+
+func main() {
+	args := os.Args
+
+	if len(args) == 1 || len(args) > 3 {
+		fmt.Println("controller and lun not provided")
+		return
+	}
+
+	// Testing in local VM: controller 0 and lun 1
+	controller := 0
+	lun := 0
+	for i, arg := range args[1:] {
+		if i == 0 {
+			controller, _ = strconv.Atoi(arg)
+		} else if i == 1 {
+			lun, _ = strconv.Atoi(arg)
+		}
+	}
+
+	fmt.Printf("Controller: %d, Lun: %d \n", controller, lun)
+
+	ctx := context.Background()
+	devPath, diskNumber, err := windevice.GetScsiDevicePathAndDiskNumberFromControllerLUN(
+		ctx,
+		uint8(controller),
+		uint8(lun))
+
+	if err != nil {
+		fmt.Printf("error getting diskNumber for LUN %d, err: %v", lun, err)
+		return
+	}
+
+	fmt.Printf("\n DevicePath: %v DiskNumber: %v \n", devPath, diskNumber)
+
+	diskPath := fmt.Sprintf(fsformatter.VirtualDevObjectPathFormat, diskNumber)
+	fmt.Printf("\n Disk path is %v", diskPath)
+
+	mountedVolumePath, err := windevice.InvokeFsFormatter(ctx, diskPath)
+
+	if err != nil {
+		fmt.Printf("error invoking formatter %v", err)
+	}
+
+	log.Printf("\n mountedVolumePath returned from InvokeFsFormatter: %v", mountedVolumePath)
+}

--- a/internal/fsformatter/formatter_driver.go
+++ b/internal/fsformatter/formatter_driver.go
@@ -1,0 +1,234 @@
+package fsformatter
+
+import (
+	"encoding/binary"
+	"log"
+	"unicode/utf16"
+	"unsafe"
+)
+
+const (
+	// This is used to construct the disk path that fsFormatter
+	// understands. `harddisk%d` here refers to the disk number
+	// associated with the corresponding lun of the attached
+	// scsi device.
+	VirtualDevObjectPathFormat                              = "\\device\\harddisk%d\\partition0"
+	CHECKSUM_TYPE_SHA256                                    = uint16(4)
+	REFS_CHECKSUM_TYPE                                      = CHECKSUM_TYPE_SHA256
+	MAX_SIZE_OF_KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS = 16 * 8 // 128 bytes
+	SIZE_OF_WCHAR                                           = int(unsafe.Sizeof(uint16(0)))
+	KERNEL_FORMAT_VOLUME_MAX_VOLUME_LABEL_LENGTH            = uint32(33 * SIZE_OF_WCHAR)
+	KERNEL_FORMAT_VOLUME_WIN32_DRIVER_PATH                  = "\\\\?\\KernelFSFormatter"
+	// Allocate large enough buffer for output from fsFormatter
+	MAX_SIZE_OF_OUTPUT_BUFFER = uint32(512)
+)
+
+type KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES uint32
+
+const (
+	KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_INVALID = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES(iota)
+	KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS    = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES(1)
+	KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_MAX     = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES(2)
+)
+
+// We only want to allow refs formatting
+func (filesystemType KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES) String() string {
+	switch filesystemType {
+	case KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS:
+		return "KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS"
+	default:
+		return "Unknown"
+	}
+}
+
+type KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS uint32
+
+const KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE = KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS(0x00000000)
+
+func (flag KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS) String() string {
+	switch flag {
+	case KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE:
+		return "KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE"
+	default:
+		return "Unknown"
+	}
+}
+
+type KernelFormatVolumeFormatRefsParameters struct {
+	ClusterSize          uint32
+	MetadataChecksumType uint16
+	UseDataIntegrity     bool
+	MajorVersion         uint16
+	MinorVersion         uint16
+}
+
+type KernelFormatVolumeFormatFsParameters struct {
+	FileSystemType KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPES
+	// Represents a WCHAR character array
+	VolumeLabel [KERNEL_FORMAT_VOLUME_MAX_VOLUME_LABEL_LENGTH / uint32(SIZE_OF_WCHAR)]uint16
+	// Length of volume label in bytes
+	VolumeLabelLength uint16
+	// RefsFormatterParams represents the following union
+	/*
+	   union {
+
+	       KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS RefsParameters;
+
+	       //
+	       //  This structure can't grow in size nor change in alignment. 16 ULONGLONGs
+	       //  should be more than enough for supporting other filesystems down the
+	       //  line. This also serves to enforce 8 byte alignment.
+	       //
+	       Reserved [16]uint64
+	   };
+	*/
+	RefsFormatterParams [128]byte
+}
+
+type KernelFormatVolumeFormatInputBuffer struct {
+	Size         uint64
+	FsParameters KernelFormatVolumeFormatFsParameters
+	Flags        KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAGS
+	Reserved     [4]uint32
+	// Size of DiskPathBuffer in bytes
+	DiskPathLength uint16
+	// DiskPathBuffer holds the disk path. It represents a
+	// variable size WCHAR character array
+	DiskPathBuffer []uint16
+}
+
+type KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS uint32
+
+const KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAG_NONE = KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS(0x00000000)
+
+func (flag KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS) String() string {
+	switch flag {
+	case KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAG_NONE:
+		return "KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAG_NONE"
+	default:
+		return "Unknown"
+	}
+}
+
+type KernelFormarVolumeFormatOutputBuffer struct {
+	Size     uint32
+	Flags    KERNEL_FORMAT_VOLUME_FORMAT_OUTPUT_BUFFER_FLAGS
+	Reserved [4]uint32
+	// VolumePathLength holds size of VolumePathBuffer
+	// in bytes
+	VolumePathLength uint16
+	// VolumePathBuffer holds the mounted volume path
+	// as returned from fsFormatter. It represents
+	// a variable size WCHAR character array
+	VolumePathBuffer []uint16
+}
+
+// GetVolumePathBufferOffset gets offset to KernelFormarVolumeFormatOutputBuffer{}.VolumePathBuffer
+func GetVolumePathBufferOffset() uint32 {
+	volPathBufferOffset := uint32(unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.Size) +
+		unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.Flags) +
+		unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.Reserved) +
+		unsafe.Sizeof(KernelFormarVolumeFormatOutputBuffer{}.VolumePathLength))
+
+	return volPathBufferOffset
+}
+
+// getInputBufferSize gets the total size needed for input buffer
+func getInputBufferSize(wcharDiskPathLength uint16) uint32 {
+	bufferSize := uint32(unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Size)+
+		unsafe.Offsetof(KernelFormatVolumeFormatFsParameters{}.RefsFormatterParams)+
+		/* this is specifically for the union inKernelFormatVolumeFormatFsParameters */
+		MAX_SIZE_OF_KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS+
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Flags)+
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Reserved)+
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.DiskPathLength)) +
+		uint32(wcharDiskPathLength)
+
+	return bufferSize
+}
+
+// getInputBufferDiskPathBufferOffset gets offset to KernelFormatVolumeFormatInputBuffer{}.DiskPathBuffer
+func getInputBufferDiskPathBufferOffset() uint32 {
+	diskPathBufferOffset := uint32(unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Size) +
+		unsafe.Offsetof(KernelFormatVolumeFormatFsParameters{}.RefsFormatterParams) +
+		MAX_SIZE_OF_KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS +
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Flags) +
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.Reserved) +
+		unsafe.Sizeof(KernelFormatVolumeFormatInputBuffer{}.DiskPathLength))
+
+	return diskPathBufferOffset
+}
+
+// KmFmtCreateFormatOutputBuffer formats an output buffer as expected
+// by the fsFormatter driver
+func KmFmtCreateFormatOutputBuffer() *KernelFormarVolumeFormatOutputBuffer {
+	buf := make([]uint16, MAX_SIZE_OF_OUTPUT_BUFFER)
+	outputBuffer := (*KernelFormarVolumeFormatOutputBuffer)(unsafe.Pointer(&buf[0]))
+	outputBuffer.Size = uint32(MAX_SIZE_OF_OUTPUT_BUFFER)
+
+	return outputBuffer
+}
+
+// KmFmtCreateFormatInputBuffer formats an input buffer as expected
+// by the fsFormatter driver.
+// diskPath represents disk path in VirtualDevObjectPathFormat.
+func KmFmtCreateFormatInputBuffer(diskPath string) *KernelFormatVolumeFormatInputBuffer {
+	refsParametersBuf := make([]byte, unsafe.Sizeof(KernelFormatVolumeFormatRefsParameters{}))
+	refsParameters := (*KernelFormatVolumeFormatRefsParameters)(unsafe.Pointer(&refsParametersBuf[0]))
+
+	utf16DiskPath := utf16.Encode([]rune(diskPath))
+	wcharDiskPathLength := uint16(len(utf16DiskPath) * SIZE_OF_WCHAR)
+
+	refsParameters.ClusterSize = 0x1000
+	refsParameters.MetadataChecksumType = REFS_CHECKSUM_TYPE
+	refsParameters.UseDataIntegrity = true
+	refsParameters.MajorVersion = uint16(3)
+	refsParameters.MinorVersion = uint16(14)
+
+	bufferSize := getInputBufferSize(wcharDiskPathLength)
+	log.Printf("\n Input buffer size: %v bytes", bufferSize)
+	buf := make([]byte, bufferSize) // bufferSize)
+	inputBuffer := (*KernelFormatVolumeFormatInputBuffer)(unsafe.Pointer(&buf[0]))
+
+	inputBuffer.Size = uint64(bufferSize)
+	inputBuffer.Flags = KERNEL_FORMAT_VOLUME_FORMAT_INPUT_BUFFER_FLAG_NONE
+
+	inputBuffer.FsParameters.FileSystemType = KERNEL_FORMAT_VOLUME_FILESYSTEM_TYPE_REFS
+	// Not setting inputBuffer.FsParameters.VolumeLabel to leave it empty
+	inputBuffer.FsParameters.VolumeLabelLength = 0 // Scratch disk need not be partitioned. Therefore pass wchar empty string.
+	inputBuffer.FsParameters.VolumeLabel = [33]uint16{}
+
+	// Write KERNEL_FORMAT_VOLUME_FORMAT_REFS_PARAMETERS
+	// Write the ClusterSize (8 bytes)
+	binary.LittleEndian.PutUint32(inputBuffer.FsParameters.RefsFormatterParams[0:], refsParameters.ClusterSize)
+	// Write the MetadataChecksumType (2 bytes)
+	binary.LittleEndian.PutUint16(inputBuffer.FsParameters.RefsFormatterParams[4:], refsParameters.MetadataChecksumType)
+	// Write the UseDataIntegrity (1 byte)
+	if refsParameters.UseDataIntegrity {
+		inputBuffer.FsParameters.RefsFormatterParams[6] = 1
+	} else {
+		inputBuffer.FsParameters.RefsFormatterParams[6] = 0
+	}
+	// Write the MajorVersion (2 bytes)
+	binary.LittleEndian.PutUint16(inputBuffer.FsParameters.RefsFormatterParams[8:], refsParameters.MajorVersion)
+	// Write the MinorVersion (2 bytes)
+	binary.LittleEndian.PutUint16(inputBuffer.FsParameters.RefsFormatterParams[10:], refsParameters.MinorVersion)
+
+	// TODO(kiashok): This can be cleaned up
+	for i := 12; i < 128; i++ {
+		inputBuffer.FsParameters.RefsFormatterParams[i] = 0 // Padding with 0s
+	}
+
+	// Finally write the diskPathLength and diskPathBuffer with the input disk path
+	inputBuffer.DiskPathLength = wcharDiskPathLength
+	// DiskBuffer writing
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(inputBuffer)) + uintptr(getInputBufferDiskPathBufferOffset()))
+	// Convert the string to UTF-16 slice
+	utf16Array := utf16.Encode([]rune(diskPath))
+	for _, val := range utf16Array {
+		*(*uint16)(ptr) = val
+		ptr = unsafe.Pointer(uintptr(unsafe.Pointer(ptr)) + uintptr(2))
+	}
+
+	return inputBuffer
+}

--- a/internal/layers/wcow_mount.go
+++ b/internal/layers/wcow_mount.go
@@ -401,7 +401,24 @@ func mountHypervIsolatedWCIFSLayers(ctx context.Context, l *wcowWCIFSLayers, vm 
 	hostPath := filepath.Join(l.scratchLayerPath, "sandbox.vhdx")
 	log.G(ctx).WithField("hostPath", hostPath).Debug("mounting scratch VHD")
 
-	scsiMount, err := vm.SCSIManager.AddVirtualDisk(ctx, hostPath, false, vm.ID(), "", &scsi.MountConfig{})
+	mountConfig := scsi.MountConfig{}
+	// NOTE: This is just an example of what needs to be done in cimfs block cim
+	// code once its merged. This will cause gcs-sidecar to invoke the refs formatter.
+	// Also note the refs formatted needs the scratch to be >= 30 GB so ensure to set
+	// the following in ContainerConfig.json:
+	/*
+		    "windows": {
+			"resources": {
+				"rootfs_size_in_bytes": 42949672960
+				}
+		    }
+	*/
+	/*
+		if vm.WCOWconfidentialUVMOptions != nil && vm.WCOWconfidentialUVMOptions.WCOWSecurityPolicy != "" {
+			mountConfig.FormatWithRefs = true
+		}
+	*/
+	scsiMount, err := vm.SCSIManager.AddVirtualDisk(ctx, hostPath, false, vm.ID(), "", &mountConfig)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to add SCSI scratch VHD: %w", err)
 	}

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Microsoft/hcsshim/internal/protocol/guestrequest"
 	"github.com/opencontainers/runtime-spec/specs-go"
 
+	"github.com/Microsoft/go-winio/pkg/guid"
 	hcsschema "github.com/Microsoft/hcsshim/internal/hcs/schema2"
 )
 
@@ -26,6 +27,10 @@ const (
 	// ResourceTypeMappedVirtualDisk is the modify resource type for mapped
 	// virtual disks
 	ResourceTypeMappedVirtualDisk guestrequest.ResourceType = "MappedVirtualDisk"
+	// ResourceTypeMappedVirtualDiskForContainerScratch is the modify resource type
+	// specifically for refs formatting and mounting scratch vhds for c-wcow cases only.
+	ResourceTypeMappedVirtualDiskForContainerScratch guestrequest.ResourceType = "MappedVirtualDiskForContainerScratch"
+	ResourceTypeWCOWBlockCims                        guestrequest.ResourceType = "WCOWBlockCims"
 	// ResourceTypeNetwork is the modify resource type for the `NetworkAdapterV2`
 	// device.
 	ResourceTypeNetwork          guestrequest.ResourceType = "Network"
@@ -96,6 +101,18 @@ type LCOWMappedVirtualDisk struct {
 	VerityInfo       *DeviceVerityInfo `json:"VerityInfo,omitempty"`
 	EnsureFilesystem bool              `json:"EnsureFilesystem,omitempty"`
 	Filesystem       string            `json:"Filesystem,omitempty"`
+}
+
+type BlockCIMDevice struct {
+	CimName string
+	Lun     int32
+}
+
+type WCOWBlockCIMMounts struct {
+	// BlockCIMs should be ordered from merged CIM followed by Layer n .. layer 1
+	BlockCIMs  []BlockCIMDevice `json:"BlockCIMs,omitempty"`
+	VolumeGuid guid.GUID        `json:"VolumeGuid,omitempty"`
+	MountFlags uint32           `json:"MountFlags,omitempty"`
 }
 
 type WCOWMappedVirtualDisk struct {

--- a/internal/uvm/scsi/backend.go
+++ b/internal/uvm/scsi/backend.go
@@ -170,6 +170,13 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 		ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
 		RequestType:  guestrequest.RequestTypeAdd,
 	}
+	// This option is set only for cwcow scratch disk mount requests
+	// where we need to format the disk with refs.
+	// For refs the scratch disk size should > 30 GB.
+	if config.formatWithRefs {
+		req.ResourceType = guestresource.ResourceTypeMappedVirtualDiskForContainerScratch
+	}
+
 	switch osType {
 	case "windows":
 		// We don't check config.readOnly here, as that will still result in the overall attachment being read-only.
@@ -185,6 +192,7 @@ func mountRequest(controller, lun uint, path string, config *mountConfig, osType
 			ContainerPath: path,
 			Lun:           int32(lun),
 		}
+
 	case "linux":
 		req.Settings = guestresource.LCOWMappedVirtualDisk{
 			MountPath:        path,

--- a/internal/uvm/scsi/manager.go
+++ b/internal/uvm/scsi/manager.go
@@ -86,6 +86,9 @@ type MountConfig struct {
 	// BlockDev indicates if the device should be mounted as a block device.
 	// This is only supported for LCOW.
 	BlockDev bool
+	// FormatWithRefs indicates to refs format the disk.
+	// This is only supported for CWCOW scratch disks.
+	FormatWithRefs bool
 }
 
 // Mount represents a SCSI device that has been attached to a VM, and potentially
@@ -162,6 +165,7 @@ func (m *Manager) AddVirtualDisk(
 			ensureFilesystem: mc.EnsureFilesystem,
 			filesystem:       mc.Filesystem,
 			blockDev:         mc.BlockDev,
+			formatWithRefs:   mc.FormatWithRefs,
 		}
 	}
 	return m.add(ctx,

--- a/internal/uvm/scsi/mount.go
+++ b/internal/uvm/scsi/mount.go
@@ -45,6 +45,7 @@ type mountConfig struct {
 	options          []string
 	ensureFilesystem bool
 	filesystem       string
+	formatWithRefs   bool
 }
 
 func (mm *mountManager) mount(ctx context.Context, controller, lun uint, path string, c *mountConfig) (_ string, err error) {

--- a/internal/wclayer/cim/mount.go
+++ b/internal/wclayer/cim/mount.go
@@ -108,7 +108,21 @@ func MergeMountBlockCIMLayer(ctx context.Context, mergedLayer *cimfs.BlockCIM, p
 	if err != nil {
 		return "", fmt.Errorf("generated cim mount GUID: %w", err)
 	}
+
+	// Assuming the call will be similar to the following:
+	//if vm == nil {
 	return cimfs.MountMergedBlockCIMs(mergedLayer, parentLayers, mountFlags, volumeGUID)
+	//	} else {
+	/*
+				// make mount request to gcs-sidecar
+		req := guestrequest.ModificationRequest{
+			ResourceType: guestresource.ResourceTypeMappedVirtualDisk,
+			RequestType:  guestrequest.RequestTypeAdd,
+		}
+
+			}
+	*/
+
 }
 
 // Unmounts the cim mounted at the given volume

--- a/internal/winapi/devices.go
+++ b/internal/winapi/devices.go
@@ -4,6 +4,8 @@ package winapi
 
 import "github.com/Microsoft/go-winio/pkg/guid"
 
+//sys CMGetDeviceInterfaceListSize(listlen *uint32, classGUID *g, deviceID *uint16, ulFlags uint32) (hr error) = cfgmgr32.CM_Get_Device_Interface_List_SizeW
+//sys CMGetDeviceInterfaceList(classGUID *g, deviceID *uint16, buffer *uint16, bufLen uint32, ulFlags uint32) (hr error) = cfgmgr32.CM_Get_Device_Interface_ListW
 //sys CMGetDeviceIDListSize(pulLen *uint32, pszFilter *byte, uFlags uint32) (hr error) = cfgmgr32.CM_Get_Device_ID_List_SizeA
 //sys CMGetDeviceIDList(pszFilter *byte, buffer *byte, bufferLen uint32, uFlags uint32) (hr error)= cfgmgr32.CM_Get_Device_ID_ListA
 //sys CMLocateDevNode(pdnDevInst *uint32, pDeviceID string, uFlags uint32) (hr error) = cfgmgr32.CM_Locate_DevNodeW

--- a/internal/winapi/zsyscall_windows.go
+++ b/internal/winapi/zsyscall_windows.go
@@ -52,6 +52,8 @@ var (
 	procCM_Get_DevNode_PropertyW               = modcfgmgr32.NewProc("CM_Get_DevNode_PropertyW")
 	procCM_Get_Device_ID_ListA                 = modcfgmgr32.NewProc("CM_Get_Device_ID_ListA")
 	procCM_Get_Device_ID_List_SizeA            = modcfgmgr32.NewProc("CM_Get_Device_ID_List_SizeA")
+	procCM_Get_Device_Interface_ListW          = modcfgmgr32.NewProc("CM_Get_Device_Interface_ListW")
+	procCM_Get_Device_Interface_List_SizeW     = modcfgmgr32.NewProc("CM_Get_Device_Interface_List_SizeW")
 	procCM_Locate_DevNodeW                     = modcfgmgr32.NewProc("CM_Locate_DevNodeW")
 	procCimAddFsToMergedImage                  = modcimfs.NewProc("CimAddFsToMergedImage")
 	procCimAddFsToMergedImage2                 = modcimfs.NewProc("CimAddFsToMergedImage2")
@@ -158,6 +160,28 @@ func CMGetDeviceIDList(pszFilter *byte, buffer *byte, bufferLen uint32, uFlags u
 
 func CMGetDeviceIDListSize(pulLen *uint32, pszFilter *byte, uFlags uint32) (hr error) {
 	r0, _, _ := syscall.SyscallN(procCM_Get_Device_ID_List_SizeA.Addr(), uintptr(unsafe.Pointer(pulLen)), uintptr(unsafe.Pointer(pszFilter)), uintptr(uFlags))
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func CMGetDeviceInterfaceList(classGUID *g, deviceID *uint16, buffer *uint16, bufLen uint32, ulFlags uint32) (hr error) {
+	r0, _, _ := syscall.SyscallN(procCM_Get_Device_Interface_ListW.Addr(), uintptr(unsafe.Pointer(classGUID)), uintptr(unsafe.Pointer(deviceID)), uintptr(unsafe.Pointer(buffer)), uintptr(bufLen), uintptr(ulFlags))
+	if int32(r0) < 0 {
+		if r0&0x1fff0000 == 0x00070000 {
+			r0 &= 0xffff
+		}
+		hr = syscall.Errno(r0)
+	}
+	return
+}
+
+func CMGetDeviceInterfaceListSize(listlen *uint32, classGUID *g, deviceID *uint16, ulFlags uint32) (hr error) {
+	r0, _, _ := syscall.SyscallN(procCM_Get_Device_Interface_List_SizeW.Addr(), uintptr(unsafe.Pointer(listlen)), uintptr(unsafe.Pointer(classGUID)), uintptr(unsafe.Pointer(deviceID)), uintptr(ulFlags))
 	if int32(r0) < 0 {
 		if r0&0x1fff0000 == 0x00070000 {
 			r0 &= 0xffff

--- a/internal/windevice/devicequery.go
+++ b/internal/windevice/devicequery.go
@@ -3,13 +3,18 @@
 package windevice
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"unicode/utf16"
+	"unsafe"
 
 	"github.com/Microsoft/go-winio/pkg/guid"
+	"github.com/Microsoft/hcsshim/internal/fsformatter"
+	"github.com/Microsoft/hcsshim/internal/log"
 	"github.com/Microsoft/hcsshim/internal/winapi"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/windows"
 )
 
 const (
@@ -22,7 +27,66 @@ const (
 	_DEVPROP_TYPE_STRING_LIST uint32 = (_DEVPROP_TYPE_STRING | _DEVPROP_TYPEMOD_LIST)
 
 	_DEVPKEY_LOCATIONPATHS_GUID = "a45c254e-df1c-4efd-8020-67d146a850e0"
+
+	_IOCTL_SCSI_GET_ADDRESS = 0x41018
+
+	_IOCTL_STORAGE_GET_DEVICE_NUMBER = 0x2d1080
+
+	_IOCTL_KERNEL_FORMAT_VOLUME_FORMAT = 0x40001000
 )
+
+var (
+	// class GUID for devices with interface type Disk
+	// 53f56307-b6bf-11d0-94f2-00a0c91efb8b
+	devClassDiskGUID = guid.GUID{
+		Data1: 0x53f56307,
+		Data2: 0xb6bf,
+		Data3: 0x11d0,
+		Data4: [8]byte{0x94, 0xf2, 0x00, 0xa0, 0xc9, 0x1e, 0xfb, 0x8b},
+	}
+)
+
+// https://learn.microsoft.com/en-us/windows/win32/api/winioctl/ns-winioctl-storage_device_number
+type STORAGE_DEVICE_NUMBER struct {
+	DeviceType      uint32
+	DeviceNumber    uint32
+	PartitionNumber uint32
+}
+
+// SCSI_ADDRESS structure used with IOCTL_SCSI_GET_ADDRESS.
+// defined here: https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntddscsi/ns-ntddscsi-_scsi_address
+type SCSIAddress struct {
+	Length     uint32
+	PortNumber uint8
+	PathId     uint8
+	TargetId   uint8
+	Lun        uint8
+}
+
+// getScsiAddress retrieves the SCSI address from a given disk handle
+func getScsiAddress(handle windows.Handle) (*SCSIAddress, error) {
+	// Create a SCSI_ADDRESS structure to receive the address information
+	address := &SCSIAddress{}
+	address.Length = uint32(unsafe.Sizeof(SCSIAddress{}))
+
+	// Buffer for the returned data
+	var bytesReturned uint32
+
+	// Call DeviceIoControl with IOCTL_SCSI_GET_ADDRESS
+	err := windows.DeviceIoControl(
+		handle,
+		_IOCTL_SCSI_GET_ADDRESS,
+		nil, 0, // no input buffer
+		(*byte)(unsafe.Pointer(address)),
+		address.Length, &bytesReturned, nil)
+	if err != nil {
+		return nil, fmt.Errorf("DeviceIoControl failed with error: %w", err)
+	}
+	if bytesReturned <= 0 {
+		return nil, fmt.Errorf("DeviceIoControl returned %d bytes", bytesReturned)
+	}
+	return address, nil
+}
 
 // getDevPKeyDeviceLocationPaths creates a DEVPROPKEY struct for the
 // DEVPKEY_Device_LocationPaths property as defined in devpkey.h
@@ -93,6 +157,21 @@ func convertFirstNullTerminatedValueToString(buf []uint16) (string, error) {
 	return converted[:zerosIndex], nil
 }
 
+func convertNullSeparatedUint16BufToStringSlice(buf []uint16) []string {
+	result := []string{}
+	r := utf16.Decode(buf)
+	converted := string(r)
+	for {
+		i := strings.IndexRune(converted, '\u0000')
+		if i <= 0 {
+			break
+		}
+		result = append(result, string(converted[:i]))
+		converted = converted[i+1:]
+	}
+	return result
+}
+
 func GetChildrenFromInstanceIDs(parentIDs []string) ([]string, error) {
 	var result []string
 	for _, id := range parentIDs {
@@ -120,4 +199,130 @@ func getDeviceIDList(pszFilter *byte, ulFlags uint32) ([]string, error) {
 	}
 
 	return winapi.ConvertStringSetToSlice(buf)
+}
+
+func getDeviceHandleFromPath(devPath string) (windows.Handle, error) {
+	utf16Path, err := windows.UTF16PtrFromString(devPath)
+	if err != nil {
+		return windows.Handle(unsafe.Pointer(nil)), fmt.Errorf("failed to convert interface path [%s] to utf16: %w", devPath, err)
+	}
+
+	handle, err := windows.CreateFile(utf16Path, windows.GENERIC_READ|windows.GENERIC_WRITE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		nil, windows.OPEN_EXISTING, 0, 0)
+	if err != nil {
+		return windows.Handle(unsafe.Pointer(nil)), fmt.Errorf("failed to get handle to interface path [%s]: %w", devPath, err)
+	}
+	return handle, nil
+}
+
+func getDeviceInterfaceList(ctx context.Context, controller, lun uint8) ([]string, error) {
+	// get a list of all disk device interfaces
+	interfaceListSize := uint32(0)
+	if err := winapi.CMGetDeviceInterfaceListSize(&interfaceListSize, &devClassDiskGUID, nil, 0); err != nil {
+		return nil, fmt.Errorf("failed to get size of disk device interface list: %w", err)
+	}
+
+	buf := make([]uint16, interfaceListSize)
+	if err := winapi.CMGetDeviceInterfaceList(&devClassDiskGUID, nil, &buf[0], interfaceListSize, 0); err != nil {
+		return nil, fmt.Errorf("failed to get disk device interface list: %w", err)
+	}
+
+	interfacePaths := convertNullSeparatedUint16BufToStringSlice(buf)
+	log.G(ctx).Debugf("disk device interface list size: %d", len(interfacePaths))
+	log.G(ctx).WithField("list", interfacePaths).Trace("disk device interfaces")
+
+	return interfacePaths, nil
+}
+
+// GetScsiDevicePathAndDiskNumberFromControllerLUN finds a storage device that has the matching
+// `controller` and `LUN` and returns its scsi device path and corresponding disk number.
+func GetScsiDevicePathAndDiskNumberFromControllerLUN(ctx context.Context, controller, LUN uint8) (string, uint64, error) {
+	interfacePaths, err := getDeviceInterfaceList(ctx, controller, LUN)
+	if err != nil {
+		return "", 0, err
+	}
+	// go over each disk device interface and find out its LUN
+	for _, iPath := range interfacePaths {
+		handle, err := getDeviceHandleFromPath(iPath)
+		if err != nil {
+			return "", 0, err
+		}
+		defer windows.Close(handle)
+
+		scsiAddr, err := getScsiAddress(handle)
+		if err != nil {
+			return "", 0, fmt.Errorf("failed to get SCSI address for interface path [%s]: %w", iPath, err)
+		}
+
+		// TODO(ambarve): is comparing controller with port number the correct way?
+		if scsiAddr.Lun == LUN && scsiAddr.PortNumber == controller {
+			// get the disk number
+			var bytesReturned uint32
+			var deviceNumber STORAGE_DEVICE_NUMBER
+			if err := windows.DeviceIoControl(
+				handle,
+				_IOCTL_STORAGE_GET_DEVICE_NUMBER,
+				nil, 0, // No input buffer
+				(*byte)(unsafe.Pointer(&deviceNumber)),
+				uint32(unsafe.Sizeof(deviceNumber)),
+				&bytesReturned,
+				nil,
+			); err != nil {
+				return "", 0, err
+			}
+			return iPath, uint64(deviceNumber.DeviceNumber), nil
+		}
+	}
+	return "", 0, fmt.Errorf("no device found with controller: %d & LUN:%d", controller, LUN)
+}
+
+// InvokeFsFormatter makes an ioctl call to the fsFormatter driver and returns
+// a path to the mountedVolume
+func InvokeFsFormatter(ctx context.Context, diskPath string) (string, error) {
+	// Prepare input and output buffers as expected by fsFormatter
+	inputBuffer := fsformatter.KmFmtCreateFormatInputBuffer(diskPath)
+	outputBuffer := fsformatter.KmFmtCreateFormatOutputBuffer()
+
+	utf16DriverPath, _ := windows.UTF16PtrFromString(fsformatter.KERNEL_FORMAT_VOLUME_WIN32_DRIVER_PATH)
+	deviceHandle, err := windows.CreateFile(utf16DriverPath,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE,
+		0,
+		nil,
+		windows.OPEN_EXISTING,
+		0,
+		0)
+	if err != nil {
+		return "", fmt.Errorf("error getting handle to fsFormatter driver: %v", err)
+	}
+	defer windows.Close(deviceHandle)
+
+	// Ioctl to fsFormatter driver
+	var bytesReturned uint32
+	if err := windows.DeviceIoControl(
+		deviceHandle,
+		_IOCTL_KERNEL_FORMAT_VOLUME_FORMAT,
+		(*byte)(unsafe.Pointer(inputBuffer)),
+		uint32(inputBuffer.Size),
+		(*byte)(unsafe.Pointer(outputBuffer)),
+		outputBuffer.Size,
+		&bytesReturned,
+		nil,
+	); err != nil {
+		return "", err
+	}
+
+	// Read the returned volume path from the corresponding offset in outputBuffer
+	ptr := unsafe.Pointer(uintptr(unsafe.Pointer(outputBuffer)) + uintptr(fsformatter.GetVolumePathBufferOffset()))
+	var result []byte
+	for i := 0; i < int(outputBuffer.VolumePathLength); i++ {
+		// Read each byte (this is unsafe, but for illustrative purposes)
+		byteVal := *((*byte)(unsafe.Pointer(uintptr(ptr) + uintptr(i))))
+		result = append(result, byteVal)
+	}
+
+	mountedVolumePath := string(result)
+	log.G(ctx).Debugf("MountedVolumePath returned: %v", mountedVolumePath)
+
+	return mountedVolumePath, err
 }

--- a/pkg/cimfs/mount_cim.go
+++ b/pkg/cimfs/mount_cim.go
@@ -15,6 +15,10 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+const (
+	VolumePathFormat = "\\\\?\\Volume{%s}\\"
+)
+
 type MountError struct {
 	Cim        string
 	Op         string
@@ -116,5 +120,5 @@ func MountMergedBlockCIMs(mergedCIM *BlockCIM, sourceCIMs []*BlockCIM, mountFlag
 	if err := winapi.CimMergeMountImage(uint32(len(cimsToMerge)), &cimsToMerge[0], mountFlags, &volumeGUID); err != nil {
 		return "", &MountError{Cim: filepath.Join(mergedCIM.BlockPath, mergedCIM.CimName), Op: "MountMerged", Err: err}
 	}
-	return fmt.Sprintf("\\\\?\\Volume{%s}\\", volumeGUID.String()), nil
+	return fmt.Sprintf(VolumePathFormat, volumeGUID.String()), nil
 }


### PR DESCRIPTION
Cherry-picks the following commit and has
changes that will not work with gcs-sidecar
outside uvm.

Add Block CIM mount and refs format support

- Add new resource type and code needed to support block cim mounts for hyperv wcow
- Add support to invoke refs formatter


(cherry picked from commit 5e48feece5ad357ca8decae49698054e75f867d9)