### PR TITLE
Psp driver cwcow

### DIFF
--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -327,8 +327,13 @@ func (b *Bridge) modifySettings(req *request) (err error) {
 		case guestresource.ResourceTypeSecurityPolicy:
 			securityPolicyRequest := modifyGuestSettingsRequest.Settings.(*guestresource.WCOWConfidentialOptions)
 			log.G(ctx).Tracef("WCOWConfidentialOptions: { %v}", securityPolicyRequest)
-			_ = b.hostState.SetWCOWConfidentialUVMOptions( /*ctx, */ securityPolicyRequest)
-
+			_ = b.hostState.SetWCOWConfidentialUVMOptions(req.ctx, securityPolicyRequest)
+			/*
+				// ignore the returned err temporarily as it fails with "unknown policy rego" error
+					; err != nil {
+						return err
+					}
+			*/
 			// Send response back to shim
 			resp := &prot.ResponseBase{
 				Result:     0, // 0 means success

--- a/internal/oci/uvm.go
+++ b/internal/oci/uvm.go
@@ -194,8 +194,17 @@ func handleAnnotationFullyPhysicallyBacked(ctx context.Context, a map[string]str
 func handleWCOWSecurityPolicy(ctx context.Context, a map[string]string, wopts *uvm.OptionsWCOW) error {
 	wopts.SecurityPolicy = ParseAnnotationsString(a, annotations.WCOWSecurityPolicy, wopts.SecurityPolicy)
 	wopts.SecurityPolicyEnforcer = ParseAnnotationsString(a, annotations.WCOWSecurityPolicyEnforcer, wopts.SecurityPolicyEnforcer)
+	// allow actual isolated boot etc to be ignored if we have no hardware. Required for dev
+	// this is not a security issue as the attestation will fail without a genuine report
+	noSecurityHardware := ParseAnnotationsBool(ctx, a, annotations.NoSecurityHardware, false)
+
+	// TODO: Process annotations.NoSecurityHardware here for cwcow cases!
 	if len(wopts.SecurityPolicy) > 0 {
 		wopts.SecurityPolicyEnabled = true
+
+		if noSecurityHardware {
+			wopts.NoSecurityHardware = true
+		}
 		return uvm.SetDefaultConfidentialWCOWBootConfig(wopts)
 	}
 	return nil

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -244,4 +244,5 @@ type WCOWConfidentialOptions struct {
 	WCOWSecurityPolicyEnabled bool
 	// Set which security policy enforcer to use (open door or rego). This allows for better fallback mechanic.
 	WCOWSecurityPolicyEnforcer string
+	NoSecurityHardware         bool
 }

--- a/internal/pspdriver/pspdriver.go
+++ b/internal/pspdriver/pspdriver.go
@@ -1,0 +1,59 @@
+package pspdriver
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Microsoft/hcsshim/internal/log"
+	"github.com/pkg/errors"
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+const (
+	serviceName = "AmdSnpPsp"
+)
+
+func StartPSPDriver(ctx context.Context) error {
+	// Connect to the Service Control Manager
+	m, err := mgr.Connect()
+	if err != nil {
+		return errors.Wrap(err, "Failed to connect to service manager")
+	}
+	defer m.Disconnect()
+
+	// Open the service
+	s, err := m.OpenService(serviceName)
+	if err != nil {
+		return errors.Wrapf(err, "Could not access service %q", serviceName)
+	}
+	defer s.Close()
+
+	// Start the service
+	err = s.Start()
+	if err != nil {
+		return errors.Wrapf(err, "Could not start service %q", serviceName)
+	}
+
+	log.G(ctx).Tracef("Service %q started successfully\n", serviceName)
+
+	// confirming the running state of the service
+	status, err := s.Query()
+	if err != nil {
+		return errors.Wrap(err, "could not query service status")
+	}
+
+	switch status.State {
+	case svc.Running:
+		fmt.Println("Service is running.")
+	case svc.Stopped:
+		fmt.Println("Service is stopped.")
+	case svc.StartPending:
+		fmt.Println("Service is starting.")
+	case svc.StopPending:
+		fmt.Println("Service is stopping.")
+	default:
+		fmt.Printf("Service state: %v\n", status.State)
+	}
+	return nil
+}

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -40,6 +40,9 @@ type ConfidentialWCOWOptions struct {
 	IsolationType      string
 	DisableSecureBoot  bool
 	FirmwareParameters string
+
+	// Temp (kiashok):
+	NoSecurityHardware bool
 }
 
 // OptionsWCOW are the set of options passed to CreateWCOW() to create a utility vm.
@@ -524,6 +527,7 @@ func CreateWCOW(ctx context.Context, opts *OptionsWCOW) (_ *UtilityVM, err error
 			WCOWSecurityPolicyEnabled:  true,
 			WCOWSecurityPolicy:         opts.SecurityPolicy,
 			WCOWSecurityPolicyEnforcer: opts.SecurityPolicyEnforcer,
+			NoSecurityHardware:         opts.NoSecurityHardware,
 		}
 		doc, err = prepareSecurityConfigDoc(ctx, uvm, opts)
 		log.G(ctx).Tracef("CreateWCOW prepareSecurityConfigDoc result doc: %v err %v", doc, err)

--- a/internal/uvm/security_policy.go
+++ b/internal/uvm/security_policy.go
@@ -45,6 +45,13 @@ func WithWCOWSecurityPolicy(policy string) WCOWConfidentialUVMOpt {
 	}
 }
 
+func WithWCOWNoSecurityHardware(noSecurityHardware bool) WCOWConfidentialUVMOpt {
+	return func(ctx context.Context, r *guestresource.WCOWConfidentialOptions) error {
+		r.NoSecurityHardware = noSecurityHardware
+		return nil
+	}
+}
+
 // WithSecurityPolicyEnforcer sets the desired enforcer type for the resource.
 func WithWCOWSecurityPolicyEnforcer(enforcer string) WCOWConfidentialUVMOpt {
 	return func(ctx context.Context, r *guestresource.WCOWConfidentialOptions) error {

--- a/internal/uvm/start.go
+++ b/internal/uvm/start.go
@@ -338,6 +338,7 @@ func (uvm *UtilityVM) Start(ctx context.Context) (err error) {
 		copts := []WCOWConfidentialUVMOpt{
 			WithWCOWSecurityPolicy(uvm.WCOWconfidentialUVMOptions.WCOWSecurityPolicy),
 			WithWCOWSecurityPolicyEnforcer(uvm.WCOWconfidentialUVMOptions.WCOWSecurityPolicyEnforcer),
+			WithWCOWNoSecurityHardware(uvm.WCOWconfidentialUVMOptions.NoSecurityHardware),
 		}
 		if err := uvm.SetWCOWConfidentialUVMOptions(ctx, copts...); err != nil {
 			return err


### PR DESCRIPTION
Uses SCM APIs to start the PSP driver if NoSecurityHardware annotation has been specified through pod config. 