### PR TITLE
[Temporary] Mock verified CIM digest for layers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/containerd/errdefs v0.3.0
 	github.com/containerd/errdefs/pkg v0.3.0
 	github.com/containerd/go-runc v1.0.0
+	github.com/containerd/log v0.1.0
 	github.com/containerd/protobuild v0.3.0
 	github.com/containerd/ttrpc v1.2.5
 	github.com/containerd/typeurl/v2 v2.2.0
@@ -51,7 +52,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/continuity v0.4.2 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
-	github.com/containerd/log v0.1.0 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect

--- a/internal/gcs-sidecar/handlers.go
+++ b/internal/gcs-sidecar/handlers.go
@@ -372,6 +372,7 @@ func (b *Bridge) modifySettings(req *request) (err error) {
 					CimName:   blockCimDevice.CimName,
 				}
 				layerCIMs = append(layerCIMs, &layerCim)
+				log.G(ctx).Debugf("block CIM layer digest %s, path: %s\n", blockCimDevice.Digest, physicalDevPath)
 			}
 			if len(layerCIMs) > 1 {
 				// Get the topmost merge CIM and invoke the MountMergedBlockCIMs

--- a/internal/protocol/guestresource/resources.go
+++ b/internal/protocol/guestresource/resources.go
@@ -110,6 +110,7 @@ type LCOWMappedVirtualDisk struct {
 type BlockCIMDevice struct {
 	CimName string
 	Lun     int32
+	Digest  string
 }
 
 type WCOWBlockCIMMounts struct {

--- a/internal/uvm/create_wcow.go
+++ b/internal/uvm/create_wcow.go
@@ -118,6 +118,7 @@ func SetDefaultConfidentialWCOWBootConfig(opts *OptionsWCOW) error {
 	opts.IsolationType = "GuestStateOnly"
 	opts.DisableSecureBoot = true
 	opts.ConsolePipe = "\\\\.\\pipe\\uvmpipe"
+	opts.NoSecurityHardware = true
 	return nil
 }
 


### PR DESCRIPTION
Verified CIMs will allow the gcs-sidecar to query the root digest for each block CIM and then validate that against the policy to see if that layer is allowed. The layer CIMs will be merge mounted only if all of the root digests of all layer CIMs are successfully validated against the policy.
However, verified CIMs aren't available yet. In order to unblock testing of the policy engine, this commit mocks the root digest of a block CIM by generating a SHA256 of the layer path on the host. As long as the layer path remains the same (i.e we won't remove and repull the same image) the layer digest will remain same and we can use that in the policy.
Note that this only a temporary change and it shouldn't be merged into main. Once verified CIMs are ready, we won't need to pass a digest in the mount block CIM request, instead gcs-sidecar will directly query the digest from the CIM.