### PR TITLE
Add default allow all policy to uvmboot

### DIFF
--- a/internal/tools/uvmboot/conf_wcow.go
+++ b/internal/tools/uvmboot/conf_wcow.go
@@ -19,6 +19,9 @@ const (
 	vmgsFilePathArgName  = "vmgs-path"
 	disableSBArgName     = "disable-secure-boot"
 	isolationTypeArgName = "isolation-type"
+
+	// default policy (that allows all operations) used when no policy is provided
+	allowAllPolicy = "cGFja2FnZSBwb2xpY3kKCmFwaV92ZXJzaW9uIDo9ICIwLjExLjAiCmZyYW1ld29ya192ZXJzaW9uIDo9ICIwLjQuMCIKCm1vdW50X2NpbXMgOj0geyJhbGxvd2VkIjogdHJ1ZX0KbW91bnRfZGV2aWNlIDo9IHsiYWxsb3dlZCI6IHRydWV9Cm1vdW50X292ZXJsYXkgOj0geyJhbGxvd2VkIjogdHJ1ZX0KY3JlYXRlX2NvbnRhaW5lciA6PSB7ImFsbG93ZWQiOiB0cnVlLCAiZW52X2xpc3QiOiBudWxsLCAiYWxsb3dfc3RkaW9fYWNjZXNzIjogdHJ1ZX0KdW5tb3VudF9kZXZpY2UgOj0geyJhbGxvd2VkIjogdHJ1ZX0KdW5tb3VudF9vdmVybGF5IDo9IHsiYWxsb3dlZCI6IHRydWV9CmV4ZWNfaW5fY29udGFpbmVyIDo9IHsiYWxsb3dlZCI6IHRydWUsICJlbnZfbGlzdCI6IG51bGx9CmV4ZWNfZXh0ZXJuYWwgOj0geyJhbGxvd2VkIjogdHJ1ZSwgImVudl9saXN0IjogbnVsbCwgImFsbG93X3N0ZGlvX2FjY2VzcyI6IHRydWV9CnNodXRkb3duX2NvbnRhaW5lciA6PSB7ImFsbG93ZWQiOiB0cnVlfQpzaWduYWxfY29udGFpbmVyX3Byb2Nlc3MgOj0geyJhbGxvd2VkIjogdHJ1ZX0KcGxhbjlfbW91bnQgOj0geyJhbGxvd2VkIjogdHJ1ZX0KcGxhbjlfdW5tb3VudCA6PSB7ImFsbG93ZWQiOiB0cnVlfQpnZXRfcHJvcGVydGllcyA6PSB7ImFsbG93ZWQiOiB0cnVlfQpkdW1wX3N0YWNrcyA6PSB7ImFsbG93ZWQiOiB0cnVlfQpydW50aW1lX2xvZ2dpbmcgOj0geyJhbGxvd2VkIjogdHJ1ZX0KbG9hZF9mcmFnbWVudCA6PSB7ImFsbG93ZWQiOiB0cnVlfQpzY3JhdGNoX21vdW50IDo9IHsiYWxsb3dlZCI6IHRydWV9CnNjcmF0Y2hfdW5tb3VudCA6PSB7ImFsbG93ZWQiOiB0cnVlfQo="
 )
 
 var (
@@ -28,6 +31,7 @@ var (
 	cwcowVMGSPath          string
 	cwcowDisableSecureBoot bool
 	cwcowIsolationMode     string
+	cwcowSecurityPolicy    string
 )
 
 var cwcowCommand = cli.Command{
@@ -79,6 +83,21 @@ var cwcowCommand = cli.Command{
 			Destination: &cwcowIsolationMode,
 			Required:    true,
 		},
+		cli.StringFlag{
+			Name:        securityPolicyArgName,
+			Usage:       "Security policy that should be enforced inside the UVM. If none is provided, default policy that allows all operations will be used.",
+			Destination: &cwcowSecurityPolicy,
+			Value:       allowAllPolicy,
+		},
+		cli.BoolFlag{
+			Name:        disableSBArgName,
+			Usage:       "Disables Secure Boot when running the UVM in confidential mode. This option is only applicable in confidential mode.",
+			Destination: &cwcowDisableSecureBoot,
+		},
+		cli.BoolFlag{
+			Name:  securityHardwareFlag,
+			Usage: "If set, UVM won't boot on  non-SNP hardware. Set to false by default",
+		},
 	},
 	Action: func(c *cli.Context) error {
 		runMany(c, func(id string) error {
@@ -91,6 +110,11 @@ var cwcowCommand = cli.Command{
 
 			// confidential specific options
 			options.SecurityPolicyEnabled = true
+			options.SecurityPolicy = cwcowSecurityPolicy
+			options.NoSecurityHardware = true
+			if c.IsSet(securityHardwareFlag) {
+				options.NoSecurityHardware = false
+			}
 			options.DisableSecureBoot = cwcowDisableSecureBoot
 			options.GuestStateFilePath = cwcowVMGSPath
 			options.IsolationType = cwcowIsolationMode


### PR DESCRIPTION
With the latest changes to sidecar GCS, we can't boot the UVM anymore without a proper policy. uvmboot tool can't be used to test/debug CWCOW uvm boots if there is no policy provided.  This commits adds a default policy and a flag to override it if required while creating UVMs with the tool.